### PR TITLE
feat(audience): implement audience reveal phase and associated components

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.0.1",
     "postcss": "^8.5.6",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -7,6 +7,7 @@ import { HostDashboard } from "./components/HostDashboard";
 import { PlayerView } from "./components/PlayerView";
 import { AdminPanel } from "./components/AdminPanel";
 import { HostLogin } from "./components/HostLogin";
+import { AudienceView } from "./components/audience/AudienceView";
 
 function HostRoute({ children }: { children: React.ReactNode }) {
   const { isHostAuthenticated, loginHost } = useAuth();
@@ -41,6 +42,7 @@ function App() {
               }
             />
             <Route path="/play" element={<PlayerView />} />
+            <Route path="/audience" element={<AudienceView />} />
             <Route path="/" element={<Navigate to="/play" replace />} />
           </Routes>
         </GameProvider>

--- a/apps/client/src/components/PlayerView.tsx
+++ b/apps/client/src/components/PlayerView.tsx
@@ -5,15 +5,15 @@ import { Clock, LogOut } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { LanguageSwitcher } from "./LanguageSwitcher";
 import { useCorrectTheErrorPartialScore } from "./player/useCorrectTheErrorPartialScore";
-import type { Competition, FillInTheBlanksContent, MatchingContent, AnswerContent, ChronologyContent, CorrectTheErrorContent, TrueFalseContent, CorrectTheErrorAnswer, MultipleChoiceContent } from "@quizco/shared";
+import type { Competition, AnswerContent, CorrectTheErrorContent, CorrectTheErrorAnswer, MultipleChoiceContent, Team } from "@quizco/shared";
 import { getHydratedPlayerAnswerState } from "./player/playerAnswerSync";
-import { Card } from "./ui/Card";
-import Badge from "./ui/Badge";
 import { CompetitionSelector } from "./player/CompetitionSelector";
 import { TeamJoinForm } from "./player/TeamJoinForm";
 import { WaitingPhase, RoundTransitionPhase, LeaderboardPhase } from "./player/SimplePhases";
 import { QuestionActivePhase } from "./player/QuestionActivePhase";
 import { RevealAnswerPhase } from "./player/RevealAnswerPhase";
+import { PublicQuestionPreview } from "./player/PublicQuestionPreview";
+import { getQuestionCorrectAnswer } from "./player/questionText";
 
 const TEAM_ID_KEY = "quizco_team_id";
 const TEAM_NAME_KEY = "quizco_team_name";
@@ -39,7 +39,7 @@ export const PlayerView: React.FC = () => {
   const lastPartialSubmissionKeyRef = useRef<string | null>(null);
   
   const teamId = state.teams.find(t => t.name === teamName)?.id || localStorage.getItem(TEAM_ID_KEY);
-  const currentTeam = state.teams.find(t => t.id === teamId);
+  const currentTeam = state.teams.find((t) => t.id === teamId) as Team | undefined;
   const hasSubmitted = currentTeam?.isExplicitlySubmitted || false;
   
   const correctTheErrorTeamAnswer = state.teams.find((t) => t.name === teamName)?.lastAnswer as CorrectTheErrorAnswer | null;
@@ -213,22 +213,7 @@ export const PlayerView: React.FC = () => {
 
   const getCorrectAnswer = () => {
     if (!state.currentQuestion) return "";
-    const { type, content } = state.currentQuestion;
-    if (type === "MULTIPLE_CHOICE") return content.correctIndices.map((idx: number) => content.options[idx]).join(", ") || "Unknown";
-    if (type === "CLOSED") return content.options[0] || "Unknown";
-    if (type === "OPEN_WORD") return content.answer;
-    if (type === "CROSSWORD") return t("player.see_grid");
-    if (type === "FILL_IN_THE_BLANKS") return (content as FillInTheBlanksContent).blanks.map(b => b.options.find(o => o.isCorrect)?.value || "??").join(", ");
-    if (type === "MATCHING") return (content as MatchingContent).pairs.map(p => `${p.left} → ${p.right}`).join(" | ");
-    if (type === "CHRONOLOGY") return [...(content as ChronologyContent).items].sort((a, b) => a.order - b.order).map(i => i.text).join(" → ");
-    if (type === "TRUE_FALSE") return (content as TrueFalseContent).isTrue ? t("game.true") : t("game.false");
-    if (type === "CORRECT_THE_ERROR") {
-      const cteContent = content as CorrectTheErrorContent;
-      const errorPhrase = cteContent.phrases[cteContent.errorPhraseIndex];
-      const errorText = typeof errorPhrase === 'object' ? errorPhrase.text : errorPhrase;
-      return `${errorText} → ${cteContent.correctReplacement}`;
-    }
-    return "Unknown";
+    return getQuestionCorrectAnswer(state.currentQuestion, t);
   };
 
   const getGradingStatus = (): boolean | undefined => {
@@ -289,40 +274,7 @@ export const PlayerView: React.FC = () => {
         )}
 
         {state.phase === "QUESTION_PREVIEW" && state.currentQuestion && (
-          <div className="w-full max-w-4xl space-y-8 animate-in fade-in duration-500">
-            {state.currentQuestion.section && (
-              <Badge variant="yellow" className="p-4 rounded-2xl border-2 border-yellow-400 animate-bounce text-2xl">
-                {t('player.turn')}: {state.currentQuestion.section}
-              </Badge>
-            )}
-            <Card variant="elevated" className="p-10 rounded-[2.5rem] border-b-8 border-yellow-500">
-              <span className="text-yellow-600 font-black uppercase tracking-widest text-lg mb-4 block">{t('player.upcoming_question')}</span>
-              <h2 className="text-4xl md:text-5xl font-black text-gray-900 leading-tight">
-                {state.currentQuestion.questionText}
-              </h2>
-            </Card>
-
-            {state.currentQuestion.type === "MULTIPLE_CHOICE" && state.revealStep > 0 && (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full mt-8">
-                {state.currentQuestion.content.options.map((opt: string, i: number) => (
-                  <div
-                    key={i}
-                    className={`p-8 rounded-3xl border-4 transition-all duration-500 transform ${i < state.revealStep
-                      ? "bg-white border-blue-100 shadow-lg scale-100 opacity-100 translate-y-0"
-                      : "bg-gray-100 border-transparent opacity-0 translate-y-4 scale-95"
-                      }`}
-                  >
-                    <span className="text-3xl font-black text-gray-800 text-left">{opt}</span>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <div className="space-y-4">
-              <Clock className="w-16 h-16 text-yellow-500 animate-spin-slow mx-auto" />
-              <p className="text-2xl font-black text-gray-500 uppercase tracking-widest">{t('player.host_reading')}</p>
-            </div>
-          </div>
+          <PublicQuestionPreview state={state} />
         )}
 
         {state.phase === "QUESTION_ACTIVE" && (

--- a/apps/client/src/components/audience/AudienceRevealPhase.test.tsx
+++ b/apps/client/src/components/audience/AudienceRevealPhase.test.tsx
@@ -78,4 +78,29 @@ describe("AudienceRevealPhase", () => {
 
     view.unmount();
   });
+
+  it("renders multiple-choice answers without pretending the audience submitted them", () => {
+    const state = buildRevealState({
+      id: "question-mc",
+      roundId: "round-1",
+      questionText: "Choose the right option",
+      type: "MULTIPLE_CHOICE",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        options: ["Wrong", "Right"],
+        correctIndices: [1],
+      },
+    });
+
+    const view = render(<AudienceRevealPhase state={state} stats={null} />);
+
+    expect(view.container.textContent).toContain("Wrong");
+    expect(view.container.textContent).toContain("Right");
+    expect(view.container.textContent).not.toContain("Your Choice");
+    expect(view.container.textContent).not.toContain("No answer submitted");
+
+    view.unmount();
+  });
 });

--- a/apps/client/src/components/audience/AudienceRevealPhase.test.tsx
+++ b/apps/client/src/components/audience/AudienceRevealPhase.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { GameState, Question } from "@quizco/shared";
+import { render } from "../../test/render";
+import { AudienceRevealPhase } from "./AudienceRevealPhase";
+
+function buildRevealState(question: Question): GameState {
+  return {
+    phase: "REVEAL_ANSWER",
+    currentQuestion: question,
+    timeRemaining: 0,
+    teams: [],
+    revealStep: 0,
+    timerPaused: false,
+  };
+}
+
+describe("AudienceRevealPhase", () => {
+  it("renders fallback correct-answer text and audience stats for simple questions", () => {
+    const state = buildRevealState({
+      id: "question-open",
+      roundId: "round-1",
+      questionText: "Name the virtue",
+      type: "OPEN_WORD",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        answer: "Patience",
+      },
+    });
+
+    const view = render(
+      <AudienceRevealPhase
+        state={state}
+        stats={{
+          totalSubmitted: 4,
+          totalCorrect: 3,
+          correctPercentage: 75,
+        }}
+      />,
+    );
+
+    expect(
+      view.container.querySelector('[data-testid="audience-correct-answer"]'),
+    ).not.toBeNull();
+    expect(view.container.textContent).toContain("Patience");
+    expect(view.container.textContent).toContain("3/4 teams correct (75%)");
+
+    view.unmount();
+  });
+
+  it("builds and renders the fully-correct chronology reveal for the audience", () => {
+    const state = buildRevealState({
+      id: "question-chronology",
+      roundId: "round-1",
+      questionText: "Put the judges in order",
+      type: "CHRONOLOGY",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        items: [
+          { id: "item-2", text: "Deborah", order: 1 },
+          { id: "item-1", text: "Othniel", order: 0 },
+          { id: "item-3", text: "Gideon", order: 2 },
+        ],
+      },
+    });
+
+    const view = render(<AudienceRevealPhase state={state} stats={null} />);
+
+    expect(view.container.textContent).toContain("Othniel");
+    expect(view.container.textContent).toContain("Deborah");
+    expect(view.container.textContent).toContain("Gideon");
+    expect(
+      view.container.querySelector('[data-testid="audience-correct-answer"]'),
+    ).toBeNull();
+
+    view.unmount();
+  });
+});

--- a/apps/client/src/components/audience/AudienceRevealPhase.tsx
+++ b/apps/client/src/components/audience/AudienceRevealPhase.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { Clock, Info } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type {
+  ChronologyAnswer,
+  ChronologyContent,
+  CorrectTheErrorContent,
+  CrosswordContent,
+  FillInTheBlanksContent,
+  GameState,
+  MatchingContent,
+  MultipleChoiceQuestion,
+} from "@quizco/shared";
+import { Card } from "../ui/Card";
+import { MultipleChoiceReveal } from "../player/MultipleChoiceReveal";
+import { ChronologyReveal } from "../player/ChronologyReveal";
+import { MatchingReveal } from "../player/MatchingReveal";
+import { FillInTheBlanksReveal } from "../player/FillInTheBlanksReveal";
+import { CrosswordReveal } from "../player/CrosswordReveal";
+import { CorrectTheErrorReveal } from "../player/CorrectTheErrorReveal";
+import type { AudienceAnswerStats } from "./audienceStats";
+import { getQuestionCorrectAnswer } from "../player/questionText";
+
+interface AudienceRevealPhaseProps {
+  state: GameState;
+  stats: AudienceAnswerStats | null;
+}
+
+function buildCorrectChronologyAnswer(
+  content: ChronologyContent,
+): ChronologyAnswer {
+  const ordered = [...content.items].sort((a, b) => a.order - b.order);
+
+  return {
+    slotIds: ordered.map((item) => item.id),
+    poolIds: [],
+  };
+}
+
+export const AudienceRevealPhase: React.FC<AudienceRevealPhaseProps> = ({
+  state,
+  stats,
+}) => {
+  const { t } = useTranslation();
+
+  if (!state.currentQuestion) {
+    return null;
+  }
+
+  const { currentQuestion } = state;
+
+  return (
+    <div className="w-full max-w-4xl space-y-8 animate-in fade-in zoom-in duration-500">
+      <Card className="p-8 border-t-8 border-blue-500 text-left">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center space-x-2 text-blue-600">
+            <Info className="w-6 h-6" />
+            <span className="font-bold uppercase tracking-widest text-sm">
+              {t("player.reveal_phase")}
+            </span>
+          </div>
+        </div>
+
+        <h2 className="text-2xl font-bold text-gray-800 mb-8">
+          {currentQuestion.questionText}
+        </h2>
+
+        <div className="space-y-6">
+          {currentQuestion.type === "MULTIPLE_CHOICE" ? (
+            <MultipleChoiceReveal
+              question={currentQuestion as MultipleChoiceQuestion}
+              lastAnswer={currentQuestion.content.correctIndices}
+            />
+          ) : currentQuestion.type === "CHRONOLOGY" ? (
+            <ChronologyReveal
+              content={currentQuestion.content as ChronologyContent}
+              lastAnswer={buildCorrectChronologyAnswer(currentQuestion.content as ChronologyContent)}
+            />
+          ) : currentQuestion.type === "MATCHING" ? (
+            <MatchingReveal
+              content={currentQuestion.content as MatchingContent}
+              lastAnswer={Object.fromEntries(
+                (currentQuestion.content as MatchingContent).pairs.map((pair) => [
+                  pair.id,
+                  pair.right,
+                ]),
+              )}
+            />
+          ) : currentQuestion.type === "FILL_IN_THE_BLANKS" ? (
+            <FillInTheBlanksReveal
+              content={currentQuestion.content as FillInTheBlanksContent}
+              lastAnswer={(currentQuestion.content as FillInTheBlanksContent).blanks.map(
+                (blank) => blank.options.find((option) => option.isCorrect)?.value || "",
+              )}
+            />
+          ) : currentQuestion.type === "CROSSWORD" ? (
+            <CrosswordReveal
+              content={currentQuestion.content as CrosswordContent}
+              lastAnswer={(currentQuestion.content as CrosswordContent).grid}
+            />
+          ) : currentQuestion.type === "CORRECT_THE_ERROR" ? (
+            <CorrectTheErrorReveal
+              content={currentQuestion.content as CorrectTheErrorContent}
+              lastAnswer={{
+                selectedPhraseIndex: (currentQuestion.content as CorrectTheErrorContent).errorPhraseIndex,
+                correction: (currentQuestion.content as CorrectTheErrorContent).correctReplacement,
+              }}
+            />
+          ) : (
+            <div
+              className="bg-green-50 p-6 rounded-2xl border-2 border-green-200"
+              data-testid="audience-correct-answer"
+            >
+              <span className="text-green-600 text-xs font-bold uppercase">
+                {t("player.correct_answer")}
+              </span>
+              <p className="text-2xl font-black text-green-900 mt-1">
+                {getQuestionCorrectAnswer(currentQuestion, t)}
+              </p>
+            </div>
+          )}
+        </div>
+      </Card>
+
+      {stats && (
+        <Card
+          className="p-6 text-left border-b-4 border-blue-500"
+          data-testid="audience-answer-stats"
+        >
+          <p className="text-sm font-bold uppercase tracking-widest text-blue-600">
+            {t("audience.answer_summary")}
+          </p>
+          <p className="mt-2 text-3xl font-black text-gray-900">
+            {t("audience.correct_count", {
+              correct: stats.totalCorrect,
+              total: stats.totalSubmitted,
+              percentage: stats.correctPercentage,
+            })}
+          </p>
+        </Card>
+      )}
+
+      <div className="bg-blue-600 text-white p-6 rounded-2xl shadow-lg animate-pulse inline-block mx-auto">
+        <p className="text-xl font-bold flex items-center">
+          <Clock className="mr-2" /> {t("player.next_soon")}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/apps/client/src/components/audience/AudienceRevealPhase.tsx
+++ b/apps/client/src/components/audience/AudienceRevealPhase.tsx
@@ -70,6 +70,7 @@ export const AudienceRevealPhase: React.FC<AudienceRevealPhaseProps> = ({
             <MultipleChoiceReveal
               question={currentQuestion as MultipleChoiceQuestion}
               lastAnswer={currentQuestion.content.correctIndices}
+              showSelectionLabels={false}
             />
           ) : currentQuestion.type === "CHRONOLOGY" ? (
             <ChronologyReveal

--- a/apps/client/src/components/audience/AudienceRevealPhase.tsx
+++ b/apps/client/src/components/audience/AudienceRevealPhase.tsx
@@ -18,6 +18,7 @@ import { MatchingReveal } from "../player/MatchingReveal";
 import { FillInTheBlanksReveal } from "../player/FillInTheBlanksReveal";
 import { CrosswordReveal } from "../player/CrosswordReveal";
 import { CorrectTheErrorReveal } from "../player/CorrectTheErrorReveal";
+import { TrueFalseReveal } from "../player/TrueFalseReveal";
 import type { AudienceAnswerStats } from "./audienceStats";
 import { getQuestionCorrectAnswer } from "../player/questionText";
 
@@ -106,6 +107,11 @@ export const AudienceRevealPhase: React.FC<AudienceRevealPhaseProps> = ({
                 selectedPhraseIndex: (currentQuestion.content as CorrectTheErrorContent).errorPhraseIndex,
                 correction: (currentQuestion.content as CorrectTheErrorContent).correctReplacement,
               }}
+            />
+          ) : currentQuestion.type === "TRUE_FALSE" ? (
+            <TrueFalseReveal
+              content={currentQuestion.content}
+              lastAnswer={currentQuestion.content.isTrue}
             />
           ) : (
             <div

--- a/apps/client/src/components/audience/AudienceView.test.tsx
+++ b/apps/client/src/components/audience/AudienceView.test.tsx
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Competition, GameState } from "@quizco/shared";
+import { GameContext } from "../../contexts/game-context";
+import { render, flushEffects } from "../../test/render";
+import { AudienceView } from "./AudienceView";
+
+const { emit } = vi.hoisted(() => ({
+  emit: vi.fn(),
+}));
+
+vi.mock("../../socket", () => ({
+  API_URL: "http://127.0.0.1:4000",
+  socket: {
+    emit,
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+const waitingState: GameState = {
+  phase: "WAITING",
+  currentQuestion: null,
+  timeRemaining: 0,
+  teams: [],
+  revealStep: 0,
+  timerPaused: false,
+};
+
+const revealState: GameState = {
+  phase: "REVEAL_ANSWER",
+  currentQuestion: {
+    id: "question-1",
+    roundId: "round-1",
+    questionText: "Which answer is correct?",
+    type: "MULTIPLE_CHOICE",
+    points: 10,
+    timeLimitSeconds: 30,
+    grading: "AUTO",
+    content: {
+      options: ["Alpha", "Beta"],
+      correctIndices: [1],
+    },
+  },
+  timeRemaining: 0,
+  teams: [],
+  revealStep: 0,
+  timerPaused: false,
+};
+
+const competitions: Competition[] = [
+  {
+    id: "comp-1",
+    title: "Audience Quiz",
+    status: "ACTIVE",
+    createdAt: "2026-03-25T10:00:00.000Z",
+    host_pin: "9999",
+  },
+];
+
+function renderAudience(state: GameState = waitingState) {
+  return render(
+    <GameContext.Provider value={{ state, dispatch: vi.fn() }}>
+      <AudienceView />
+    </GameContext.Provider>,
+  );
+}
+
+describe("AudienceView", () => {
+  beforeEach(() => {
+    emit.mockClear();
+    window.localStorage.clear();
+    window.history.replaceState({}, "", "/audience");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string) => {
+        if (input.endsWith("/api/competitions")) {
+          return {
+            json: async () => competitions,
+          } as Response;
+        }
+
+        return {
+          json: async () => [],
+        } as Response;
+      }),
+    );
+  });
+
+  it("renders the competition selector when no competition is chosen", async () => {
+    const view = renderAudience();
+    await flushEffects();
+
+    expect(
+      view.container.querySelector('[data-testid="competition-selector"]'),
+    ).not.toBeNull();
+    expect(view.container.textContent).toContain("Audience Quiz");
+    view.unmount();
+  });
+
+  it("honors the competition query param and joins passively", async () => {
+    window.history.replaceState({}, "", "/audience?competitionId=comp-1");
+
+    const view = renderAudience();
+    await flushEffects();
+
+    expect(
+      view.container.querySelector('[data-testid="audience-phase"]'),
+    ).not.toBeNull();
+    expect(emit).toHaveBeenCalledWith("HOST_JOIN_ROOM", {
+      competitionId: "comp-1",
+    });
+    view.unmount();
+  });
+
+  it("shows reveal stats after the correct answer is revealed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string) => {
+        if (input.endsWith("/api/competitions")) {
+          return {
+            json: async () => competitions,
+          } as Response;
+        }
+
+        return {
+          json: async () => [
+            { isCorrect: true },
+            { isCorrect: true },
+            { isCorrect: true },
+            { isCorrect: true },
+            { isCorrect: false },
+          ],
+        } as Response;
+      }),
+    );
+
+    window.history.replaceState({}, "", "/audience?competitionId=comp-1");
+
+    const view = renderAudience(revealState);
+    await flushEffects();
+    await flushEffects();
+
+    expect(view.container.textContent).toContain("Beta");
+    expect(view.container.textContent).toContain("4/5 teams correct (80%)");
+    expect(
+      view.container.querySelector('[data-testid="audience-answer-stats"]'),
+    ).not.toBeNull();
+
+    view.unmount();
+  });
+});

--- a/apps/client/src/components/audience/AudienceView.test.tsx
+++ b/apps/client/src/components/audience/AudienceView.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Competition, GameState } from "@quizco/shared";
 import { GameContext } from "../../contexts/game-context";
-import { render, flushEffects } from "../../test/render";
+import { click, render, flushEffects } from "../../test/render";
 import { AudienceView } from "./AudienceView";
 
 const { emit } = vi.hoisted(() => ({
@@ -47,6 +47,48 @@ const revealState: GameState = {
   timerPaused: false,
 };
 
+const crosswordActiveState: GameState = {
+  phase: "QUESTION_ACTIVE",
+  currentQuestion: {
+    id: "question-2",
+    roundId: "round-1",
+    questionText: "Audience crossword question",
+    type: "CROSSWORD",
+    points: 10,
+    timeLimitSeconds: 30,
+    grading: "AUTO",
+    content: {
+      grid: [["A", "B"], ["", "C"]],
+      clues: {
+        across: [
+          {
+            number: 1,
+            x: 0,
+            y: 0,
+            direction: "across",
+            clue: "Audience across clue",
+            answer: "AB",
+          },
+        ],
+        down: [
+          {
+            number: 2,
+            x: 1,
+            y: 0,
+            direction: "down",
+            clue: "Audience down clue",
+            answer: "BC",
+          },
+        ],
+      },
+    },
+  },
+  timeRemaining: 18,
+  teams: [],
+  revealStep: 0,
+  timerPaused: false,
+};
+
 const competitions: Competition[] = [
   {
     id: "comp-1",
@@ -67,8 +109,25 @@ function renderAudience(state: GameState = waitingState) {
 
 describe("AudienceView", () => {
   beforeEach(() => {
+    const storage = new Map<string, string>();
+
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        clear: () => {
+          storage.clear();
+        },
+      },
+    });
+
     emit.mockClear();
-    window.localStorage.clear();
     window.history.replaceState({}, "", "/audience");
 
     vi.stubGlobal(
@@ -113,6 +172,29 @@ describe("AudienceView", () => {
     view.unmount();
   });
 
+  it("persists a selected competition to local storage and the URL", async () => {
+    const view = renderAudience();
+    await flushEffects();
+
+    const selector = view.container.querySelector(
+      '[data-testid="competition-option-comp-1"]',
+    );
+
+    expect(selector).not.toBeNull();
+    click(selector as HTMLElement);
+    await flushEffects();
+
+    expect(window.localStorage.getItem("quizco_audience_competition_id")).toBe(
+      "comp-1",
+    );
+    expect(window.location.search).toContain("competitionId=comp-1");
+    expect(emit).toHaveBeenCalledWith("HOST_JOIN_ROOM", {
+      competitionId: "comp-1",
+    });
+
+    view.unmount();
+  });
+
   it("shows reveal stats after the correct answer is revealed", async () => {
     vi.stubGlobal(
       "fetch",
@@ -146,6 +228,28 @@ describe("AudienceView", () => {
     expect(
       view.container.querySelector('[data-testid="audience-answer-stats"]'),
     ).not.toBeNull();
+
+    view.unmount();
+  });
+
+  it("renders crossword questions passively for the audience during active play", async () => {
+    window.history.replaceState({}, "", "/audience?competitionId=comp-1");
+
+    const view = renderAudience(crosswordActiveState);
+    await flushEffects();
+
+    expect(view.container.textContent).toContain("Audience crossword question");
+    expect(view.container.textContent).toContain("Audience across clue");
+    expect(view.container.textContent).toContain("Audience down clue");
+    expect(
+      view.container.querySelector('[data-testid="audience-crossword"]'),
+    ).not.toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="crossword-submit"]'),
+    ).toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="crossword-cell-0-0"]'),
+    ).toBeNull();
 
     view.unmount();
   });

--- a/apps/client/src/components/audience/AudienceView.test.tsx
+++ b/apps/client/src/components/audience/AudienceView.test.tsx
@@ -245,6 +245,15 @@ describe("AudienceView", () => {
       view.container.querySelector('[data-testid="audience-crossword"]'),
     ).not.toBeNull();
     expect(
+      view.container.querySelector('[data-testid="audience-crossword-cell-0-0"]'),
+    ).not.toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="audience-crossword-across-0"]'),
+    ).not.toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="audience-crossword-down-0"]'),
+    ).not.toBeNull();
+    expect(
       view.container.querySelector('[data-testid="crossword-submit"]'),
     ).toBeNull();
     expect(

--- a/apps/client/src/components/audience/AudienceView.tsx
+++ b/apps/client/src/components/audience/AudienceView.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+import type { Competition } from "@quizco/shared";
+import { useTranslation } from "react-i18next";
+import { useGame } from "../../contexts/useGame";
+import { API_URL, socket } from "../../socket";
+import { LanguageSwitcher } from "../LanguageSwitcher";
+import { CompetitionSelector } from "../player/CompetitionSelector";
+import { WaitingPhase, RoundTransitionPhase, LeaderboardPhase } from "../player/SimplePhases";
+import { PublicQuestionPreview } from "../player/PublicQuestionPreview";
+import { PublicQuestionBody } from "../player/PublicQuestionBody";
+import { AudienceRevealPhase } from "./AudienceRevealPhase";
+import type { AudienceAnswerRecord } from "./audienceStats";
+import { buildAudienceAnswerStats } from "./audienceStats";
+
+const AUDIENCE_COMP_ID_KEY = "quizco_audience_competition_id";
+
+function getInitialCompetitionId(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("competitionId") || localStorage.getItem(AUDIENCE_COMP_ID_KEY);
+}
+
+export const AudienceView: React.FC = () => {
+  const { t } = useTranslation();
+  const { state } = useGame();
+  const [competitions, setCompetitions] = React.useState<Competition[]>([]);
+  const [selectedCompId, setSelectedCompId] = React.useState<string | null>(
+    getInitialCompetitionId(),
+  );
+  const [stats, setStats] = React.useState<ReturnType<typeof buildAudienceAnswerStats>>(null);
+
+  React.useEffect(() => {
+    document.title = "BC Audience";
+  }, []);
+
+  React.useEffect(() => {
+    fetch(`${API_URL}/api/competitions`)
+      .then((response) => response.json())
+      .then((data) => setCompetitions(data));
+  }, []);
+
+  React.useEffect(() => {
+    if (!selectedCompId) {
+      return;
+    }
+
+    localStorage.setItem(AUDIENCE_COMP_ID_KEY, selectedCompId);
+
+    const params = new URLSearchParams(window.location.search);
+    params.set("competitionId", selectedCompId);
+    const newUrl = `${window.location.pathname}?${params.toString()}`;
+    window.history.replaceState({ path: newUrl }, "", newUrl);
+
+    socket.emit("HOST_JOIN_ROOM", { competitionId: selectedCompId });
+  }, [selectedCompId]);
+
+  React.useEffect(() => {
+    if (
+      !selectedCompId ||
+      !state.currentQuestion ||
+      !["QUESTION_ACTIVE", "GRADING", "REVEAL_ANSWER"].includes(state.phase)
+    ) {
+      setStats(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    fetch(
+      `${API_URL}/api/competitions/${selectedCompId}/questions/${state.currentQuestion.id}/answers`,
+    )
+      .then((response) => response.json())
+      .then((data: AudienceAnswerRecord[]) => {
+        if (!cancelled) {
+          setStats(buildAudienceAnswerStats(Array.isArray(data) ? data : []));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedCompId, state.currentQuestion, state.phase, state.revealStep, state.teams]);
+
+  if (!selectedCompId) {
+    return (
+      <CompetitionSelector
+        competitions={competitions}
+        onSelect={(competitionId) => setSelectedCompId(competitionId)}
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <header className="bg-white shadow-sm p-4 flex justify-between items-center">
+        <h1 className="font-bold text-lg text-gray-800">{t("audience.title")}</h1>
+        <LanguageSwitcher />
+      </header>
+
+      <main className="flex-1 flex flex-col items-center justify-center p-6 text-center">
+        <div data-testid="audience-phase" className="sr-only">
+          {state.phase}
+        </div>
+
+        {(state.phase === "WAITING" || state.phase === "WELCOME") && <WaitingPhase />}
+
+        {(state.phase === "ROUND_START" || state.phase === "ROUND_END") && (
+          <RoundTransitionPhase
+            phase={state.phase}
+            currentQuestion={state.currentQuestion}
+          />
+        )}
+
+        {state.phase === "QUESTION_PREVIEW" && state.currentQuestion && (
+          <PublicQuestionPreview state={state} testIdPrefix="audience" />
+        )}
+
+        {state.phase === "QUESTION_ACTIVE" && state.currentQuestion && (
+          <div className="w-full max-w-3xl space-y-8">
+            <PublicQuestionBody
+              mode="readOnly"
+              state={state}
+              hasSubmitted={false}
+              selectedIndices={[]}
+              answer=""
+              setAnswer={() => undefined}
+              toggleIndex={() => undefined}
+              submitAnswer={() => undefined}
+              submissionStatus="idle"
+              testIdPrefix="audience"
+            />
+            <div
+              className="text-4xl font-black text-gray-300"
+              data-testid="audience-time-remaining"
+            >
+              {state.timeRemaining}s
+            </div>
+          </div>
+        )}
+
+        {state.phase === "GRADING" && state.currentQuestion && (
+          <div className="w-full max-w-3xl space-y-8">
+            <PublicQuestionBody
+              mode="readOnly"
+              state={state}
+              hasSubmitted={false}
+              selectedIndices={[]}
+              answer=""
+              setAnswer={() => undefined}
+              toggleIndex={() => undefined}
+              submitAnswer={() => undefined}
+              submissionStatus="idle"
+              testIdPrefix="audience"
+            />
+            <p className="text-xl text-gray-500">{t("player.grading_waiting")}</p>
+          </div>
+        )}
+
+        {state.phase === "REVEAL_ANSWER" && (
+          <AudienceRevealPhase state={state} stats={stats} />
+        )}
+
+        {state.phase === "LEADERBOARD" && <LeaderboardPhase teams={state.teams} />}
+      </main>
+    </div>
+  );
+};

--- a/apps/client/src/components/audience/audienceStats.test.ts
+++ b/apps/client/src/components/audience/audienceStats.test.ts
@@ -21,4 +21,19 @@ describe("buildAudienceAnswerStats", () => {
       correctPercentage: 80,
     });
   });
+
+  it("ignores ungraded answers when calculating audience totals", () => {
+    expect(
+      buildAudienceAnswerStats([
+        { isCorrect: true },
+        { isCorrect: null },
+        { isCorrect: false },
+        { isCorrect: null },
+      ]),
+    ).toEqual({
+      totalSubmitted: 2,
+      totalCorrect: 1,
+      correctPercentage: 50,
+    });
+  });
 });

--- a/apps/client/src/components/audience/audienceStats.test.ts
+++ b/apps/client/src/components/audience/audienceStats.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildAudienceAnswerStats } from "./audienceStats";
+
+describe("buildAudienceAnswerStats", () => {
+  it("returns hidden when no answers were submitted", () => {
+    expect(buildAudienceAnswerStats([])).toBeNull();
+  });
+
+  it("returns totals and rounded percentage from submitted answers", () => {
+    expect(
+      buildAudienceAnswerStats([
+        { isCorrect: true },
+        { isCorrect: true },
+        { isCorrect: true },
+        { isCorrect: true },
+        { isCorrect: false },
+      ]),
+    ).toEqual({
+      totalSubmitted: 5,
+      totalCorrect: 4,
+      correctPercentage: 80,
+    });
+  });
+});

--- a/apps/client/src/components/audience/audienceStats.ts
+++ b/apps/client/src/components/audience/audienceStats.ts
@@ -1,0 +1,26 @@
+export interface AudienceAnswerRecord {
+  isCorrect: boolean | null;
+}
+
+export interface AudienceAnswerStats {
+  totalSubmitted: number;
+  totalCorrect: number;
+  correctPercentage: number;
+}
+
+export function buildAudienceAnswerStats(
+  answers: AudienceAnswerRecord[],
+): AudienceAnswerStats | null {
+  if (answers.length === 0) {
+    return null;
+  }
+
+  const totalSubmitted = answers.length;
+  const totalCorrect = answers.filter((answer) => answer.isCorrect === true).length;
+
+  return {
+    totalSubmitted,
+    totalCorrect,
+    correctPercentage: Math.round((totalCorrect / totalSubmitted) * 100),
+  };
+}

--- a/apps/client/src/components/audience/audienceStats.ts
+++ b/apps/client/src/components/audience/audienceStats.ts
@@ -11,12 +11,16 @@ export interface AudienceAnswerStats {
 export function buildAudienceAnswerStats(
   answers: AudienceAnswerRecord[],
 ): AudienceAnswerStats | null {
-  if (answers.length === 0) {
+  const gradedAnswers = answers.filter((answer) => answer.isCorrect !== null);
+
+  if (gradedAnswers.length === 0) {
     return null;
   }
 
-  const totalSubmitted = answers.length;
-  const totalCorrect = answers.filter((answer) => answer.isCorrect === true).length;
+  const totalSubmitted = gradedAnswers.length;
+  const totalCorrect = gradedAnswers.filter(
+    (answer) => answer.isCorrect === true,
+  ).length;
 
   return {
     totalSubmitted,

--- a/apps/client/src/components/player/ChronologyPlayer.tsx
+++ b/apps/client/src/components/player/ChronologyPlayer.tsx
@@ -32,6 +32,7 @@ interface ChronologyPlayerProps {
   content: ChronologyContent;
   value: ChronologyAnswer;
   onChange: (value: ChronologyAnswer) => void;
+  disabled?: boolean;
 }
 
 interface ChronologyItemView {
@@ -294,6 +295,7 @@ export const ChronologyPlayer: React.FC<ChronologyPlayerProps> = ({
   content,
   value,
   onChange,
+  disabled = false,
 }) => {
   const { t } = useTranslation();
   const itemIds = useMemo(() => content.items.map((item) => item.id), [content.items]);
@@ -339,12 +341,18 @@ export const ChronologyPlayer: React.FC<ChronologyPlayerProps> = ({
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
+    if (disabled) {
+      return;
+    }
     setActiveId(String(event.active.id));
-  }, []);
+  }, [disabled]);
 
   const handleDragOver = useCallback((event: DragOverEvent) => {
+    if (disabled) {
+      return;
+    }
     setOverId(event.over ? String(event.over.id) : null);
-  }, []);
+  }, [disabled]);
 
   const resetDragState = useCallback(() => {
     setActiveId(null);
@@ -364,6 +372,11 @@ export const ChronologyPlayer: React.FC<ChronologyPlayerProps> = ({
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      if (disabled) {
+        resetDragState();
+        return;
+      }
+
       const { active, over } = event;
       const sourceSlotIndex = boardState.slotIds.findIndex(
         (slotId) => slotId === String(active.id),
@@ -417,7 +430,7 @@ export const ChronologyPlayer: React.FC<ChronologyPlayerProps> = ({
 
       resetDragState();
     },
-    [boardState, onChange, overId, resetDragState],
+    [boardState, disabled, onChange, overId, resetDragState],
   );
 
   const activeItem = activeId ? itemMap[activeId] : null;
@@ -429,7 +442,7 @@ export const ChronologyPlayer: React.FC<ChronologyPlayerProps> = ({
       </p>
 
       <DndContext
-        sensors={sensors}
+        sensors={disabled ? [] : sensors}
         collisionDetection={collisionDetection}
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}

--- a/apps/client/src/components/player/CrosswordAudienceView.tsx
+++ b/apps/client/src/components/player/CrosswordAudienceView.tsx
@@ -1,0 +1,118 @@
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { CrosswordClue, CrosswordContent } from "@quizco/shared";
+import { ArrowBigDown, ArrowBigRight } from "lucide-react";
+
+interface CrosswordAudienceViewProps {
+  content: CrosswordContent;
+  testIdPrefix?: string;
+}
+
+function calculateCellNumbers(clues: CrosswordContent["clues"]): Map<string, number> {
+  const cellToNumber = new Map<string, number>();
+
+  const allClues: CrosswordClue[] = [...(clues.across || []), ...(clues.down || [])];
+  const uniqueStarts = new Map<string, CrosswordClue[]>();
+
+  allClues.forEach((clue) => {
+    const key = `${clue.y}-${clue.x}`;
+    if (!uniqueStarts.has(key)) {
+      uniqueStarts.set(key, []);
+    }
+    uniqueStarts.get(key)?.push(clue);
+  });
+
+  uniqueStarts.forEach((startingClues, key) => {
+    cellToNumber.set(key, startingClues[0].number);
+  });
+
+  return cellToNumber;
+}
+
+export const CrosswordAudienceView: React.FC<CrosswordAudienceViewProps> = ({
+  content,
+  testIdPrefix = "audience",
+}) => {
+  const { t } = useTranslation();
+  const cellNumbers = useMemo(
+    () => calculateCellNumbers(content.clues),
+    [content.clues],
+  );
+
+  return (
+    <div
+      className="flex flex-col md:flex-row gap-8 items-start"
+      data-testid={`${testIdPrefix}-crossword`}
+    >
+      <div
+        className="grid gap-1 bg-gray-300 p-1 rounded shadow-lg"
+        style={{
+          gridTemplateColumns: `repeat(${content.grid?.[0]?.length || 0}, 48px)`,
+        }}
+      >
+        {content.grid.map((row, rowIndex) =>
+          row.map((cell, columnIndex) => {
+            const cellNumber = cellNumbers.get(`${rowIndex}-${columnIndex}`);
+            const isBlocked = cell.trim() === "";
+
+            return (
+              <div
+                key={`${rowIndex}-${columnIndex}`}
+                data-testid={`${testIdPrefix}-crossword-cell-${rowIndex}-${columnIndex}`}
+                className="w-12 h-12 flex items-center justify-center rounded-sm relative bg-white"
+              >
+                {isBlocked ? (
+                  <div className="w-full h-full bg-gray-800 rounded-sm" />
+                ) : (
+                  <>
+                    {cellNumber && (
+                      <span className="absolute top-0.5 left-1 text-[12px] font-bold text-blue-600 leading-none">
+                        {cellNumber}
+                      </span>
+                    )}
+                    <span className="text-xl font-bold uppercase text-gray-700 opacity-40">
+                      &bull;
+                    </span>
+                  </>
+                )}
+              </div>
+            );
+          }),
+        )}
+      </div>
+
+      <div className="flex-1 space-y-4 text-left">
+        <div>
+          <h3 className="font-bold text-lg bg-blue-600 text-white rounded-lg mb-2 p-2 inline-flex items-center gap-1">
+            {t("host.across")} <ArrowBigRight className="fill-white w-5 h-5" />
+          </h3>
+          <ul className="space-y-1">
+            {content.clues.across.map((clue, index) => (
+              <li
+                key={index}
+                data-testid={`${testIdPrefix}-crossword-across-${index}`}
+              >
+                <span className="font-bold">{clue.number}.</span> {clue.clue}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-bold text-lg bg-blue-600 text-white rounded-lg mb-2 p-2 inline-flex items-center gap-1">
+            {t("host.down")} <ArrowBigDown className="fill-white w-5 h-5" />
+          </h3>
+          <ul className="space-y-1">
+            {content.clues.down.map((clue, index) => (
+              <li
+                key={index}
+                data-testid={`${testIdPrefix}-crossword-down-${index}`}
+              >
+                <span className="font-bold">{clue.number}.</span> {clue.clue}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/client/src/components/player/CrosswordPlayer.tsx
+++ b/apps/client/src/components/player/CrosswordPlayer.tsx
@@ -4,6 +4,7 @@ import { socket } from "../../socket";
 import { useTranslation } from "react-i18next";
 import { Send, ArrowBigRight, ArrowBigDown } from "lucide-react";
 import { useGame } from "../../contexts/useGame";
+import { isStringGrid } from "../../utils/answerGuards";
 
 interface CrosswordPlayerProps {
   data: CrosswordContent;
@@ -11,6 +12,8 @@ interface CrosswordPlayerProps {
   onChange?: (grid: string[][]) => void;
   onSubmit?: (grid: string[][]) => void;
   onProgress?: (grid: string[][]) => void;
+  readOnly?: boolean;
+  testIdPrefix?: string;
 }
 
 /**
@@ -66,6 +69,8 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
   onChange,
   onSubmit,
   onProgress,
+  readOnly = false,
+  testIdPrefix = "crossword",
 }) => {
   const { t } = useTranslation();
   const { state } = useGame();
@@ -82,6 +87,9 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
     return data.grid.map((row) => row.map(() => ""));
   }, [data.grid]);
 
+  const fallbackGrid = useMemo(() => initializeGrid(), [initializeGrid]);
+  const controlledGrid = isStringGrid(value) ? value : undefined;
+
   // Use external value if provided, otherwise use internal state
   const [internalGrid, setInternalGrid] = useState<string[][]>(() => initializeGrid());
 
@@ -94,7 +102,7 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
   // Use provided value or internal state. If the grid shape changed in uncontrolled mode,
   // fallback to a fresh grid without setting state inside an effect.
   const userGrid =
-    value ?? (hasValidInternalGridShape ? internalGrid : initializeGrid());
+    controlledGrid ?? (hasValidInternalGridShape ? internalGrid : fallbackGrid);
 
   // State for highlighted cells when clicking on clues
   const [highlightedCells, setHighlightedCells] = useState<string[]>([]);
@@ -194,6 +202,10 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
   };
 
   useEffect(() => {
+    if (readOnly) {
+      return undefined;
+    }
+
     const handleJoker = (payload: {
       x: number;
       y: number;
@@ -217,9 +229,13 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
     return () => {
       socket.off("JOKER_REVEAL", handleJoker);
     };
-  }, [userGrid, onChange]);
+  }, [readOnly, userGrid, onChange]);
 
   const handleRequestJoker = () => {
+    if (readOnly) {
+      return;
+    }
+
     const teamId = localStorage.getItem("quizco_team_id");
     const competitionId = localStorage.getItem("quizco_selected_competition_id");
     if (teamId && competitionId && state.currentQuestion) {
@@ -232,7 +248,7 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
   };
 
   const handleSubmit = () => {
-    if (onSubmit) {
+    if (!readOnly && onSubmit) {
       onSubmit(userGrid);
     }
   };
@@ -306,18 +322,20 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex justify-end">
-        <button
-          onClick={handleRequestJoker}
-          className="bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-2 px-4 rounded-lg shadow transition flex items-center space-x-2"
-        >
-          <span className="text-xl">🃏</span>
-          <span>
-            {t("game.request_joker", "Request Joker")} (-2pts)
-          </span>
-        </button>
-      </div>
+    <div className="space-y-4" data-testid={`${testIdPrefix}-crossword`}>
+      {!readOnly && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleRequestJoker}
+            className="bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-2 px-4 rounded-lg shadow transition flex items-center space-x-2"
+          >
+            <span className="text-xl">🃏</span>
+            <span>
+              {t("game.request_joker", "Request Joker")} (-2pts)
+            </span>
+          </button>
+        </div>
+      )}
       <div className="flex flex-col md:flex-row gap-8 items-start">
         <div
           className="grid gap-1 bg-gray-300 p-1 rounded shadow-lg"
@@ -346,23 +364,34 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
                           {cellNumber}
                         </span>
                       )}
-                      <input
-                        type="text"
-                        value={cell}
-                        onChange={(e) => handleChange(r, c, e.target.value)}
-                        onFocus={() => handleCellFocus(r, c)}
-                        data-testid={`crossword-cell-${r}-${c}`}
-                        ref={(el) => {
-                          if (el) {
-                            inputRefs.current.set(`${r}-${c}`, el);
-                          } else {
-                            inputRefs.current.delete(`${r}-${c}`);
-                          }
-                        }}
-                        className={`w-full h-full text-center text-xl font-bold uppercase outline-none focus:bg-yellow-100 rounded-sm ${
-                          isHighlighted ? "!bg-blue-200" : "bg-transparent"
-                        }`}
-                      />
+                      {readOnly ? (
+                        <span
+                          data-testid={`${testIdPrefix}-crossword-cell-${r}-${c}`}
+                          className={`w-full h-full flex items-center justify-center text-center text-xl font-bold uppercase rounded-sm ${
+                            isHighlighted ? "!bg-blue-200" : "bg-transparent"
+                          }`}
+                        >
+                          {cell}
+                        </span>
+                      ) : (
+                        <input
+                          type="text"
+                          value={cell}
+                          onChange={(e) => handleChange(r, c, e.target.value)}
+                          onFocus={() => handleCellFocus(r, c)}
+                          data-testid={`crossword-cell-${r}-${c}`}
+                          ref={(el) => {
+                            if (el) {
+                              inputRefs.current.set(`${r}-${c}`, el);
+                            } else {
+                              inputRefs.current.delete(`${r}-${c}`);
+                            }
+                          }}
+                          className={`w-full h-full text-center text-xl font-bold uppercase outline-none focus:bg-yellow-100 rounded-sm ${
+                            isHighlighted ? "!bg-blue-200" : "bg-transparent"
+                          }`}
+                        />
+                      )}
                     </>
                   )}
                 </div>
@@ -379,6 +408,7 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
                 <li 
                   key={i}
                   onClick={() => handleClueClick(clue, i)}
+                  data-testid={`${testIdPrefix}-crossword-across-${i}`}
                   className={`cursor-pointer px-2 py-1 rounded hover:bg-blue-100 transition ${
                     selectedClueIndex === i ? "bg-blue-200 font-semibold" : ""
                   }`}
@@ -395,6 +425,7 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
                 <li 
                   key={i}
                   onClick={() => handleClueClick(clue, i + (data.clues?.across?.length || 0))}
+                  data-testid={`${testIdPrefix}-crossword-down-${i}`}
                   className={`cursor-pointer px-2 py-1 rounded hover:bg-blue-100 transition ${
                     selectedClueIndex === i + (data.clues?.across?.length || 0) ? "bg-blue-200 font-semibold" : ""
                   }`}
@@ -407,18 +438,19 @@ export const CrosswordPlayer: React.FC<CrosswordPlayerProps> = ({
         </div>
       </div>
 
-      {/* Submit Button */}
-      <div className="mt-6">
-        <button
-          onClick={handleSubmit}
-          data-testid="crossword-submit"
-          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-4 px-6 rounded-2xl text-2xl flex items-center justify-center space-x-2 shadow-lg transition"
-        >
-          <Send className="w-8 h-8" />
+      {!readOnly && (
+        <div className="mt-6">
+          <button
+            onClick={handleSubmit}
+            data-testid="crossword-submit"
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-4 px-6 rounded-2xl text-2xl flex items-center justify-center space-x-2 shadow-lg transition"
+          >
+            <Send className="w-8 h-8" />
 
-          <span>{t("player.submit_crossword", "Submit Crossword")}</span>
-        </button>
-      </div>
+            <span>{t("player.submit_crossword", "Submit Crossword")}</span>
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/client/src/components/player/MultipleChoiceReveal.test.tsx
+++ b/apps/client/src/components/player/MultipleChoiceReveal.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { MultipleChoiceQuestion } from "@quizco/shared";
+import { render } from "../../test/render";
+import { MultipleChoiceReveal } from "./MultipleChoiceReveal";
+
+const question: MultipleChoiceQuestion = {
+  id: "question-1",
+  roundId: "round-1",
+  questionText: "Choose one",
+  type: "MULTIPLE_CHOICE",
+  points: 10,
+  timeLimitSeconds: 30,
+  grading: "AUTO",
+  content: {
+    options: ["Wrong", "Right"],
+    correctIndices: [1],
+  },
+};
+
+describe("MultipleChoiceReveal", () => {
+  it("shows selection labels in interactive mode", () => {
+    const view = render(
+      <MultipleChoiceReveal question={question} lastAnswer={[1]} />,
+    );
+
+    expect(view.container.textContent).toContain("Your Choice");
+    expect(view.container.textContent).toContain("Right");
+
+    view.unmount();
+  });
+
+  it("renders neutral audience reveal without selection labels", () => {
+    const view = render(
+      <MultipleChoiceReveal
+        question={question}
+        lastAnswer={question.content.correctIndices}
+        showSelectionLabels={false}
+      />,
+    );
+
+    expect(view.container.textContent).toContain("Wrong");
+    expect(view.container.textContent).toContain("Right");
+    expect(view.container.textContent).not.toContain("Your Choice");
+    expect(view.container.textContent).not.toContain("No answer submitted");
+
+    view.unmount();
+  });
+});

--- a/apps/client/src/components/player/MultipleChoiceReveal.tsx
+++ b/apps/client/src/components/player/MultipleChoiceReveal.tsx
@@ -6,6 +6,7 @@ import type { MultipleChoiceQuestion } from "@quizco/shared";
 interface MultipleChoiceRevealProps {
   question: MultipleChoiceQuestion;
   lastAnswer: number[] | null;
+  showSelectionLabels?: boolean;
 }
 
 /**
@@ -18,6 +19,7 @@ interface MultipleChoiceRevealProps {
 export const MultipleChoiceReveal: React.FC<MultipleChoiceRevealProps> = ({
   question,
   lastAnswer,
+  showSelectionLabels = true,
 }) => {
   const { t } = useTranslation();
 
@@ -50,7 +52,7 @@ export const MultipleChoiceReveal: React.FC<MultipleChoiceRevealProps> = ({
               {opt}
             </span>
             <div className="flex items-center space-x-3">
-              {isSelected && (
+              {showSelectionLabels && isSelected && (
                 <span
                   className={`text-xs font-black uppercase px-2 py-1 rounded ${
                     isOptionCorrect
@@ -62,7 +64,7 @@ export const MultipleChoiceReveal: React.FC<MultipleChoiceRevealProps> = ({
                 </span>
               )}
               {isOptionCorrect && <CheckCircle className="text-green-600 w-8 h-8" />}
-              {isSelected && !isOptionCorrect && (
+              {showSelectionLabels && isSelected && !isOptionCorrect && (
                 <XCircle className="text-red-600 w-8 h-8" />
               )}
             </div>

--- a/apps/client/src/components/player/PublicQuestionBody.test.tsx
+++ b/apps/client/src/components/player/PublicQuestionBody.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import type { GameState, MultipleChoiceQuestion } from "@quizco/shared";
-import { render } from "../../test/render";
+import type {
+  CrosswordQuestion,
+  GameState,
+  MultipleChoiceQuestion,
+} from "@quizco/shared";
+import { click, render } from "../../test/render";
+import { GameContext } from "../../contexts/game-context";
 import { PublicQuestionBody } from "./PublicQuestionBody";
 
 const question: MultipleChoiceQuestion = {
@@ -24,6 +29,41 @@ const state: GameState = {
   teams: [],
   revealStep: 0,
   timerPaused: false,
+};
+
+const crosswordQuestion: CrosswordQuestion = {
+  id: "question-2",
+  roundId: "round-1",
+  questionText: "Fill the crossword",
+  type: "CROSSWORD",
+  points: 10,
+  timeLimitSeconds: 30,
+  grading: "AUTO",
+  content: {
+    grid: [["A", "B"], ["", "C"]],
+    clues: {
+      across: [
+        {
+          number: 1,
+          x: 0,
+          y: 0,
+          direction: "across",
+          clue: "First row",
+          answer: "AB",
+        },
+      ],
+      down: [
+        {
+          number: 2,
+          x: 1,
+          y: 0,
+          direction: "down",
+          clue: "Second column",
+          answer: "BC",
+        },
+      ],
+    },
+  },
 };
 
 describe("PublicQuestionBody", () => {
@@ -52,6 +92,113 @@ describe("PublicQuestionBody", () => {
     expect(
       view.container.querySelector('[data-testid="audience-choice-0"]'),
     ).not.toBeNull();
+
+    view.unmount();
+  });
+
+  it("keeps interactive multiple-choice controls wired after the refactor", () => {
+    const toggleIndex = vi.fn();
+    const submitAnswer = vi.fn();
+    const view = render(
+      <PublicQuestionBody
+        mode="interactive"
+        state={state}
+        answer=""
+        selectedIndices={[1]}
+        setAnswer={vi.fn()}
+        toggleIndex={toggleIndex}
+        submitAnswer={submitAnswer}
+        hasSubmitted={false}
+        submissionStatus="idle"
+      />,
+    );
+
+    const choice = view.container.querySelector(
+      '[data-testid="player-choice-0"]',
+    );
+    const submit = view.container.querySelector(
+      '[data-testid="player-submit-answer"]',
+    );
+
+    expect(choice).not.toBeNull();
+    expect(submit).not.toBeNull();
+
+    click(choice as HTMLElement);
+    click(submit as HTMLElement);
+
+    expect(toggleIndex).toHaveBeenCalledWith(0);
+    expect(submitAnswer).toHaveBeenCalledWith([1], true);
+
+    view.unmount();
+  });
+
+  it("shows the section badge for individual-play questions", () => {
+    const sectionState: GameState = {
+      ...state,
+      currentQuestion: {
+        ...question,
+        section: "Player A",
+      },
+    };
+
+    const view = render(
+      <PublicQuestionBody
+        mode="readOnly"
+        state={sectionState}
+        answer=""
+        selectedIndices={[]}
+        setAnswer={vi.fn()}
+        toggleIndex={vi.fn()}
+        submitAnswer={vi.fn()}
+        hasSubmitted={false}
+        submissionStatus="idle"
+      />,
+    );
+
+    expect(view.container.textContent).toContain("Turn: Player A");
+
+    view.unmount();
+  });
+
+  it("renders crossword questions in read-only mode for the audience", () => {
+    const crosswordState: GameState = {
+      ...state,
+      currentQuestion: crosswordQuestion,
+    };
+
+    const view = render(
+      <GameContext.Provider value={{ state: crosswordState, dispatch: vi.fn() }}>
+        <PublicQuestionBody
+          mode="readOnly"
+          state={crosswordState}
+          answer=""
+          selectedIndices={[]}
+          setAnswer={vi.fn()}
+          toggleIndex={vi.fn()}
+          submitAnswer={vi.fn()}
+          hasSubmitted={false}
+          submissionStatus="idle"
+          testIdPrefix="audience"
+        />
+      </GameContext.Provider>,
+    );
+
+    expect(view.container.textContent).toContain("Fill the crossword");
+    expect(view.container.textContent).toContain("First row");
+    expect(view.container.textContent).toContain("Second column");
+    expect(
+      view.container.querySelector('[data-testid="audience-crossword"]'),
+    ).not.toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="audience-crossword-cell-0-0"]'),
+    ).not.toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="crossword-submit"]'),
+    ).toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="crossword-cell-0-0"]'),
+    ).toBeNull();
+    expect(view.container.textContent).not.toContain("Request Joker");
 
     view.unmount();
   });

--- a/apps/client/src/components/player/PublicQuestionBody.test.tsx
+++ b/apps/client/src/components/player/PublicQuestionBody.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GameState, MultipleChoiceQuestion } from "@quizco/shared";
+import { render } from "../../test/render";
+import { PublicQuestionBody } from "./PublicQuestionBody";
+
+const question: MultipleChoiceQuestion = {
+  id: "question-1",
+  roundId: "round-1",
+  questionText: "Choose one",
+  type: "MULTIPLE_CHOICE",
+  points: 10,
+  timeLimitSeconds: 30,
+  grading: "AUTO",
+  content: {
+    options: ["One", "Two"],
+    correctIndices: [1],
+  },
+};
+
+const state: GameState = {
+  phase: "QUESTION_ACTIVE",
+  currentQuestion: question,
+  timeRemaining: 22,
+  teams: [],
+  revealStep: 0,
+  timerPaused: false,
+};
+
+describe("PublicQuestionBody", () => {
+  it("renders read-only active question content without submit controls", () => {
+    const view = render(
+      <PublicQuestionBody
+        mode="readOnly"
+        state={state}
+        answer=""
+        selectedIndices={[]}
+        setAnswer={vi.fn()}
+        toggleIndex={vi.fn()}
+        submitAnswer={vi.fn()}
+        hasSubmitted={false}
+        submissionStatus="idle"
+        testIdPrefix="audience"
+      />,
+    );
+
+    expect(view.container.textContent).toContain("Choose one");
+    expect(view.container.textContent).toContain("One");
+    expect(view.container.textContent).toContain("Two");
+    expect(
+      view.container.querySelector('[data-testid="player-submit-answer"]'),
+    ).toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="audience-choice-0"]'),
+    ).not.toBeNull();
+
+    view.unmount();
+  });
+});

--- a/apps/client/src/components/player/PublicQuestionBody.test.tsx
+++ b/apps/client/src/components/player/PublicQuestionBody.test.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
+  ClosedQuestion,
   CrosswordQuestion,
   GameState,
   MultipleChoiceQuestion,
+  OpenWordQuestion,
 } from "@quizco/shared";
 import { click, render } from "../../test/render";
-import { GameContext } from "../../contexts/game-context";
 import { PublicQuestionBody } from "./PublicQuestionBody";
 
 const question: MultipleChoiceQuestion = {
@@ -63,6 +64,32 @@ const crosswordQuestion: CrosswordQuestion = {
         },
       ],
     },
+  },
+};
+
+const closedQuestion: ClosedQuestion = {
+  id: "question-3",
+  roundId: "round-1",
+  questionText: "Name the builder",
+  type: "CLOSED",
+  points: 10,
+  timeLimitSeconds: 30,
+  grading: "AUTO",
+  content: {
+    options: ["Noah"],
+  },
+};
+
+const openWordQuestion: OpenWordQuestion = {
+  id: "question-4",
+  roundId: "round-1",
+  questionText: "Type the answer",
+  type: "OPEN_WORD",
+  points: 10,
+  timeLimitSeconds: 30,
+  grading: "AUTO",
+  content: {
+    answer: "Noah",
   },
 };
 
@@ -167,20 +194,18 @@ describe("PublicQuestionBody", () => {
     };
 
     const view = render(
-      <GameContext.Provider value={{ state: crosswordState, dispatch: vi.fn() }}>
-        <PublicQuestionBody
-          mode="readOnly"
-          state={crosswordState}
-          answer=""
-          selectedIndices={[]}
-          setAnswer={vi.fn()}
-          toggleIndex={vi.fn()}
-          submitAnswer={vi.fn()}
-          hasSubmitted={false}
-          submissionStatus="idle"
-          testIdPrefix="audience"
-        />
-      </GameContext.Provider>,
+      <PublicQuestionBody
+        mode="readOnly"
+        state={crosswordState}
+        answer=""
+        selectedIndices={[]}
+        setAnswer={vi.fn()}
+        toggleIndex={vi.fn()}
+        submitAnswer={vi.fn()}
+        hasSubmitted={false}
+        submissionStatus="idle"
+        testIdPrefix="audience"
+      />,
     );
 
     expect(view.container.textContent).toContain("Fill the crossword");
@@ -193,6 +218,12 @@ describe("PublicQuestionBody", () => {
       view.container.querySelector('[data-testid="audience-crossword-cell-0-0"]'),
     ).not.toBeNull();
     expect(
+      view.container.querySelector('[data-testid="audience-crossword-across-0"]'),
+    ).not.toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="audience-crossword-down-0"]'),
+    ).not.toBeNull();
+    expect(
       view.container.querySelector('[data-testid="crossword-submit"]'),
     ).toBeNull();
     expect(
@@ -200,6 +231,50 @@ describe("PublicQuestionBody", () => {
     ).toBeNull();
     expect(view.container.textContent).not.toContain("Request Joker");
 
+    view.unmount();
+  });
+
+  it("renders closed questions in read-only mode", () => {
+    const view = render(
+      <PublicQuestionBody
+        mode="readOnly"
+        state={{ ...state, currentQuestion: closedQuestion }}
+        answer=""
+        selectedIndices={[]}
+        setAnswer={vi.fn()}
+        toggleIndex={vi.fn()}
+        submitAnswer={vi.fn()}
+        hasSubmitted={false}
+        submissionStatus="idle"
+        testIdPrefix="audience"
+      />,
+    );
+
+    expect(view.container.textContent).toContain("Name the builder");
+    expect(view.container.textContent).toContain("Noah");
+    view.unmount();
+  });
+
+  it("renders open-word questions in read-only mode", () => {
+    const view = render(
+      <PublicQuestionBody
+        mode="readOnly"
+        state={{ ...state, currentQuestion: openWordQuestion }}
+        answer=""
+        selectedIndices={[]}
+        setAnswer={vi.fn()}
+        toggleIndex={vi.fn()}
+        submitAnswer={vi.fn()}
+        hasSubmitted={false}
+        submissionStatus="idle"
+        testIdPrefix="audience"
+      />,
+    );
+
+    expect(view.container.textContent).toContain("Type the answer");
+    expect(view.container.textContent).toContain(
+      "Audience will see the correct answer after reveal",
+    );
     view.unmount();
   });
 });

--- a/apps/client/src/components/player/PublicQuestionBody.tsx
+++ b/apps/client/src/components/player/PublicQuestionBody.tsx
@@ -21,6 +21,7 @@ import { MatchingPlayer } from "./MatchingPlayer";
 import { ChronologyPlayer } from "./ChronologyPlayer";
 import TrueFalsePlayer from "./TrueFalsePlayer";
 import CorrectTheErrorPlayer from "./CorrectTheErrorPlayer";
+import { CrosswordAudienceView } from "./CrosswordAudienceView";
 import { isChronologyAnswer, isStringGrid } from "../../utils/answerGuards";
 
 interface PublicQuestionBodyProps {
@@ -126,28 +127,35 @@ export const PublicQuestionBody: React.FC<PublicQuestionBodyProps> = ({
           </div>
         ) : currentQuestion.type === "CROSSWORD" ? (
           <div className="bg-white p-4 rounded-xl shadow-inner max-h-[60vh] overflow-auto">
-            <CrosswordPlayer
-              data={currentQuestion.content}
-              value={
-                isStringGrid(answer)
-                  ? answer
-                  : (currentQuestion.content as CrosswordContent).grid.map((row) =>
-                      row.map(() => "")
-                    )
-              }
-              onChange={(grid) => {
-                if (!isReadOnly) {
-                  setAnswer(grid);
+            {isReadOnly ? (
+              <CrosswordAudienceView
+                content={currentQuestion.content as CrosswordContent}
+                testIdPrefix={testIdPrefix}
+              />
+            ) : (
+              <CrosswordPlayer
+                data={currentQuestion.content as CrosswordContent}
+                value={
+                  isStringGrid(answer)
+                    ? answer
+                    : (currentQuestion.content as CrosswordContent).grid.map((row) =>
+                        row.map(() => "")
+                      )
                 }
-              }}
-              onSubmit={(grid) => {
-                if (!isReadOnly) {
-                  submitAnswer(grid, true);
-                }
-              }}
-              readOnly={isReadOnly}
-              testIdPrefix={testIdPrefix}
-            />
+                onChange={(grid) => {
+                  if (!isReadOnly) {
+                    setAnswer(grid);
+                  }
+                }}
+                onSubmit={(grid) => {
+                  if (!isReadOnly) {
+                    submitAnswer(grid, true);
+                  }
+                }}
+                readOnly={false}
+                testIdPrefix={testIdPrefix}
+              />
+            )}
           </div>
         ) : currentQuestion.type === "FILL_IN_THE_BLANKS" ? (
           <div className="space-y-6">
@@ -275,7 +283,16 @@ export const PublicQuestionBody: React.FC<PublicQuestionBodyProps> = ({
               </Button>
             )}
           </div>
-        ) : isReadOnly ? null : (
+        ) : isReadOnly ? (
+          <div
+            className="bg-white p-8 rounded-3xl shadow-xl border-b-8 border-blue-500 text-left leading-loose text-2xl font-medium text-gray-800"
+            data-testid={`${testIdPrefix}-passive-answer-placeholder`}
+          >
+            {currentQuestion.type === "CLOSED"
+              ? currentQuestion.content.options.join(", ")
+              : t("audience.open_answer_hidden")}
+          </div>
+        ) : (
           <div className="flex flex-col space-y-4">
             <Input
               type="text"

--- a/apps/client/src/components/player/PublicQuestionBody.tsx
+++ b/apps/client/src/components/player/PublicQuestionBody.tsx
@@ -1,0 +1,296 @@
+import React from "react";
+import { Send } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type {
+  AnswerContent,
+  ChronologyContent,
+  CorrectTheErrorAnswer,
+  CorrectTheErrorContent,
+  GameState,
+  MatchingContent,
+  MultipleChoiceContent,
+} from "@quizco/shared";
+import Button from "../ui/Button";
+import Input from "../ui/Input";
+import Badge from "../ui/Badge";
+import { Card } from "../ui/Card";
+import { CrosswordPlayer } from "./CrosswordPlayer";
+import { FillInTheBlanksPlayer } from "./FillInTheBlanksPlayer";
+import { MatchingPlayer } from "./MatchingPlayer";
+import { ChronologyPlayer } from "./ChronologyPlayer";
+import TrueFalsePlayer from "./TrueFalsePlayer";
+import CorrectTheErrorPlayer from "./CorrectTheErrorPlayer";
+import { isChronologyAnswer } from "../../utils/answerGuards";
+
+interface PublicQuestionBodyProps {
+  mode: "interactive" | "readOnly";
+  state: GameState;
+  hasSubmitted: boolean;
+  selectedIndices: number[];
+  answer: AnswerContent;
+  setAnswer: (value: AnswerContent) => void;
+  toggleIndex: (index: number) => void;
+  submitAnswer: (value: AnswerContent, isFinal?: boolean) => void;
+  submissionStatus: "idle" | "success" | "error";
+  currentTeam?: { isExplicitlySubmitted?: boolean };
+  testIdPrefix?: string;
+}
+
+export const PublicQuestionBody: React.FC<PublicQuestionBodyProps> = ({
+  mode,
+  state,
+  hasSubmitted,
+  selectedIndices,
+  answer,
+  setAnswer,
+  toggleIndex,
+  submitAnswer,
+  testIdPrefix = "player",
+}) => {
+  const { t } = useTranslation();
+  const { currentQuestion } = state;
+
+  if (!currentQuestion) {
+    return null;
+  }
+
+  const isReadOnly = mode === "readOnly";
+
+  return (
+    <div className="space-y-8 text-left">
+      {currentQuestion.section && (
+        <Badge
+          variant="yellow"
+          className="p-4 rounded-2xl border-2 border-yellow-400 text-2xl"
+        >
+          {t("player.turn")}: {currentQuestion.section}
+        </Badge>
+      )}
+
+      <Card className="p-8 border-b-4 border-blue-500">
+        <span className="text-blue-600 font-bold uppercase tracking-wider text-sm">
+          {t("player.question")}
+        </span>
+        <h2
+          className="text-2xl md:text-3xl font-bold mt-2 text-gray-800"
+          data-testid={`${testIdPrefix}-active-question-text`}
+        >
+          {currentQuestion.questionText}
+        </h2>
+      </Card>
+
+      <div className="space-y-6 w-full">
+        {currentQuestion.type === "MULTIPLE_CHOICE" ? (
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {(currentQuestion.content as MultipleChoiceContent).options.map(
+                (option: string, index: number) => {
+                  const isSelected = selectedIndices.includes(index);
+                  const classes =
+                    isReadOnly
+                      ? "bg-white border-gray-100 text-gray-700"
+                      : isSelected
+                        ? "bg-blue-600 border-blue-400 text-white shadow-lg translate-y-[-2px]"
+                        : "bg-white border-gray-100 text-gray-700 hover:border-blue-200";
+
+                  return (
+                    <button
+                      key={index}
+                      type="button"
+                      disabled={isReadOnly || hasSubmitted}
+                      onClick={() => toggleIndex(index)}
+                      data-testid={`${testIdPrefix}-choice-${index}`}
+                      className={`border-4 p-6 rounded-2xl text-xl font-black transition-all transform text-left flex items-center justify-between ${classes}`}
+                    >
+                      <span>{option}</span>
+                    </button>
+                  );
+                },
+              )}
+            </div>
+
+            {!isReadOnly && (
+              <Button
+                variant="primary"
+                onClick={() => submitAnswer(selectedIndices, true)}
+                disabled={selectedIndices.length === 0}
+                size="xl"
+                data-testid="player-submit-answer"
+                className={`w-full ${selectedIndices.length > 0 ? "translate-y-[-4px]" : ""}`}
+              >
+                <Send className="w-8 h-8 mr-3" />
+                <span>{t("player.submit_answer")}</span>
+              </Button>
+            )}
+          </div>
+        ) : currentQuestion.type === "CROSSWORD" ? (
+          <div className="bg-white p-4 rounded-xl shadow-inner max-h-[60vh] overflow-auto">
+            <CrosswordPlayer
+              data={currentQuestion.content}
+              value={answer as string[][]}
+              onChange={(grid) => {
+                if (!isReadOnly) {
+                  setAnswer(grid);
+                }
+              }}
+              onSubmit={(grid) => {
+                if (!isReadOnly) {
+                  submitAnswer(grid, true);
+                }
+              }}
+            />
+          </div>
+        ) : currentQuestion.type === "FILL_IN_THE_BLANKS" ? (
+          <div className="space-y-6">
+            <FillInTheBlanksPlayer
+              content={currentQuestion.content}
+              value={(answer as string[]) || []}
+              onChange={(value) => setAnswer(value)}
+              disabled={isReadOnly}
+            />
+            {!isReadOnly && (
+              <Button
+                onClick={() => submitAnswer(answer, true)}
+                data-testid="player-submit-answer"
+                className="w-full py-6 rounded-3xl text-3xl shadow-xl"
+              >
+                <Send className="w-8 h-8 mr-2" />
+                <span>{t("player.submit_answer")}</span>
+              </Button>
+            )}
+          </div>
+        ) : currentQuestion.type === "MATCHING" ? (
+          <div className="space-y-6">
+            <MatchingPlayer
+              content={currentQuestion.content}
+              value={(answer as Record<string, string>) || {}}
+              onChange={(value) => setAnswer(value)}
+              disabled={isReadOnly}
+            />
+            {!isReadOnly && (
+              <Button
+                onClick={() => submitAnswer(answer, true)}
+                disabled={
+                  Object.keys(answer || {}).length <
+                  (currentQuestion.content as MatchingContent).pairs.length
+                }
+                data-testid="player-submit-answer"
+                className="w-full py-6 rounded-3xl text-3xl shadow-xl"
+              >
+                <Send className="w-8 h-8 mr-2" />
+                <span>{t("player.submit_answer")}</span>
+              </Button>
+            )}
+          </div>
+        ) : currentQuestion.type === "CHRONOLOGY" ? (
+          <div className="space-y-6">
+            <ChronologyPlayer
+              key={currentQuestion.id}
+              content={currentQuestion.content}
+              value={
+                isChronologyAnswer(answer)
+                  ? answer
+                  : {
+                      slotIds: (currentQuestion.content as ChronologyContent).items.map(
+                        () => null,
+                      ),
+                      poolIds: (currentQuestion.content as ChronologyContent).items.map(
+                        (item) => item.id,
+                      ),
+                    }
+              }
+              onChange={(value) => {
+                if (!isReadOnly) {
+                  setAnswer(value);
+                }
+              }}
+              disabled={isReadOnly}
+            />
+            {!isReadOnly && (
+              <Button
+                onClick={() => submitAnswer(answer, true)}
+                data-testid="player-submit-answer"
+                className="w-full py-6 rounded-3xl text-3xl shadow-xl"
+              >
+                <Send className="w-8 h-8 mr-2" />
+                <span>{t("player.submit_answer")}</span>
+              </Button>
+            )}
+          </div>
+        ) : currentQuestion.type === "TRUE_FALSE" ? (
+          <div className="space-y-6">
+            <TrueFalsePlayer
+              selectedAnswer={answer as boolean | null}
+              disabled={hasSubmitted || isReadOnly}
+              onAnswer={(value) => {
+                setAnswer(value);
+              }}
+            />
+            {!isReadOnly && (
+              <Button
+                onClick={() => submitAnswer(answer, true)}
+                disabled={answer === null}
+                data-testid="player-submit-answer"
+                className="w-full py-6 rounded-3xl text-3xl shadow-xl"
+              >
+                <Send className="w-8 h-8 mr-2" />
+                <span>{t("player.submit_answer")}</span>
+              </Button>
+            )}
+          </div>
+        ) : currentQuestion.type === "CORRECT_THE_ERROR" ? (
+          <div className="space-y-6">
+            <CorrectTheErrorPlayer
+              content={currentQuestion.content as CorrectTheErrorContent}
+              value={
+                (answer as CorrectTheErrorAnswer) || {
+                  selectedPhraseIndex: -1,
+                  correction: "",
+                }
+              }
+              onChange={(value) => setAnswer(value)}
+              disabled={hasSubmitted || isReadOnly}
+            />
+            {!isReadOnly && !hasSubmitted && (
+              <Button
+                onClick={() => submitAnswer(answer, true)}
+                disabled={
+                  (answer as CorrectTheErrorAnswer).selectedPhraseIndex === -1 ||
+                  !(answer as CorrectTheErrorAnswer).correction
+                }
+                data-testid="player-submit-answer"
+                className="w-full py-6 rounded-3xl text-3xl shadow-xl"
+              >
+                <Send className="w-8 h-8 mr-2" />
+                <span>{t("player.submit_answer")}</span>
+              </Button>
+            )}
+          </div>
+        ) : isReadOnly ? null : (
+          <div className="flex flex-col space-y-4">
+            <Input
+              type="text"
+              value={String(answer)}
+              onChange={(event) => setAnswer(event.target.value)}
+              onKeyDown={(event) =>
+                event.key === "Enter" && submitAnswer(answer, true)
+              }
+              className="text-2xl"
+              placeholder={t("player.type_answer")}
+              data-testid="player-open-answer-input"
+            />
+            <Button
+              onClick={() => submitAnswer(answer, true)}
+              size="lg"
+              data-testid="player-submit-answer"
+              className="shadow-lg"
+            >
+              <Send className="mr-2" />
+              <span>{t("player.submit_answer")}</span>
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/client/src/components/player/PublicQuestionBody.tsx
+++ b/apps/client/src/components/player/PublicQuestionBody.tsx
@@ -6,6 +6,7 @@ import type {
   ChronologyContent,
   CorrectTheErrorAnswer,
   CorrectTheErrorContent,
+  CrosswordContent,
   GameState,
   MatchingContent,
   MultipleChoiceContent,
@@ -20,7 +21,7 @@ import { MatchingPlayer } from "./MatchingPlayer";
 import { ChronologyPlayer } from "./ChronologyPlayer";
 import TrueFalsePlayer from "./TrueFalsePlayer";
 import CorrectTheErrorPlayer from "./CorrectTheErrorPlayer";
-import { isChronologyAnswer } from "../../utils/answerGuards";
+import { isChronologyAnswer, isStringGrid } from "../../utils/answerGuards";
 
 interface PublicQuestionBodyProps {
   mode: "interactive" | "readOnly";
@@ -127,7 +128,13 @@ export const PublicQuestionBody: React.FC<PublicQuestionBodyProps> = ({
           <div className="bg-white p-4 rounded-xl shadow-inner max-h-[60vh] overflow-auto">
             <CrosswordPlayer
               data={currentQuestion.content}
-              value={answer as string[][]}
+              value={
+                isStringGrid(answer)
+                  ? answer
+                  : (currentQuestion.content as CrosswordContent).grid.map((row) =>
+                      row.map(() => "")
+                    )
+              }
               onChange={(grid) => {
                 if (!isReadOnly) {
                   setAnswer(grid);
@@ -138,6 +145,8 @@ export const PublicQuestionBody: React.FC<PublicQuestionBodyProps> = ({
                   submitAnswer(grid, true);
                 }
               }}
+              readOnly={isReadOnly}
+              testIdPrefix={testIdPrefix}
             />
           </div>
         ) : currentQuestion.type === "FILL_IN_THE_BLANKS" ? (

--- a/apps/client/src/components/player/PublicQuestionPreview.test.tsx
+++ b/apps/client/src/components/player/PublicQuestionPreview.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { GameState, MultipleChoiceQuestion } from "@quizco/shared";
+import { render } from "../../test/render";
+import { PublicQuestionPreview } from "./PublicQuestionPreview";
+
+const question: MultipleChoiceQuestion = {
+  id: "question-1",
+  roundId: "round-1",
+  questionText: "Which answer is correct?",
+  type: "MULTIPLE_CHOICE",
+  points: 10,
+  timeLimitSeconds: 30,
+  grading: "AUTO",
+  content: {
+    options: ["Alpha", "Beta", "Gamma"],
+    correctIndices: [1],
+  },
+};
+
+const state: GameState = {
+  phase: "QUESTION_PREVIEW",
+  currentQuestion: question,
+  timeRemaining: 30,
+  teams: [],
+  revealStep: 2,
+  timerPaused: false,
+};
+
+describe("PublicQuestionPreview", () => {
+  it("shows only the options revealed by the current reveal step", () => {
+    const view = render(<PublicQuestionPreview state={state} testIdPrefix="audience" />);
+
+    expect(view.container.textContent).toContain("Alpha");
+    expect(view.container.textContent).toContain("Beta");
+    expect(view.container.textContent).not.toContain("Gamma");
+    expect(
+      view.container.querySelector('[data-testid="audience-preview-option-2"]'),
+    ).toBeNull();
+
+    view.unmount();
+  });
+});

--- a/apps/client/src/components/player/PublicQuestionPreview.tsx
+++ b/apps/client/src/components/player/PublicQuestionPreview.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Clock } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { GameState } from "@quizco/shared";
+import Badge from "../ui/Badge";
+import { Card } from "../ui/Card";
+
+interface PublicQuestionPreviewProps {
+  state: GameState;
+  testIdPrefix?: string;
+}
+
+export const PublicQuestionPreview: React.FC<PublicQuestionPreviewProps> = ({
+  state,
+  testIdPrefix = "player",
+}) => {
+  const { t } = useTranslation();
+
+  if (!state.currentQuestion) {
+    return null;
+  }
+
+  return (
+    <div className="w-full max-w-4xl space-y-8 animate-in fade-in duration-500">
+      {state.currentQuestion.section && (
+        <Badge
+          variant="yellow"
+          className="p-4 rounded-2xl border-2 border-yellow-400 animate-bounce text-2xl"
+        >
+          {t("player.turn")}: {state.currentQuestion.section}
+        </Badge>
+      )}
+      <Card
+        variant="elevated"
+        className="p-10 rounded-[2.5rem] border-b-8 border-yellow-500"
+      >
+        <span className="text-yellow-600 font-black uppercase tracking-widest text-lg mb-4 block">
+          {t("player.upcoming_question")}
+        </span>
+        <h2 className="text-4xl md:text-5xl font-black text-gray-900 leading-tight">
+          {state.currentQuestion.questionText}
+        </h2>
+      </Card>
+
+      {state.currentQuestion.type === "MULTIPLE_CHOICE" && state.revealStep > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full mt-8">
+          {state.currentQuestion.content.options.map((option: string, index: number) =>
+            index < state.revealStep ? (
+              <div
+                key={index}
+                data-testid={`${testIdPrefix}-preview-option-${index}`}
+                className="p-8 rounded-3xl border-4 transition-all duration-500 transform bg-white border-blue-100 shadow-lg scale-100 opacity-100 translate-y-0"
+              >
+                <span className="text-3xl font-black text-gray-800 text-left">
+                  {option}
+                </span>
+              </div>
+            ) : null,
+          )}
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <Clock className="w-16 h-16 text-yellow-500 animate-spin-slow mx-auto" />
+        <p className="text-2xl font-black text-gray-500 uppercase tracking-widest">
+          {t("player.host_reading")}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/apps/client/src/components/player/QuestionActivePhase.test.tsx
+++ b/apps/client/src/components/player/QuestionActivePhase.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GameState, MultipleChoiceQuestion } from "@quizco/shared";
+import { render } from "../../test/render";
+import { QuestionActivePhase } from "./QuestionActivePhase";
+
+const question: MultipleChoiceQuestion = {
+  id: "question-1",
+  roundId: "round-1",
+  questionText: "Choose one",
+  type: "MULTIPLE_CHOICE",
+  points: 10,
+  timeLimitSeconds: 30,
+  grading: "AUTO",
+  content: {
+    options: ["One", "Two"],
+    correctIndices: [1],
+  },
+};
+
+const state: GameState = {
+  phase: "QUESTION_ACTIVE",
+  currentQuestion: question,
+  timeRemaining: 22,
+  teams: [],
+  revealStep: 0,
+  timerPaused: false,
+};
+
+describe("QuestionActivePhase", () => {
+  it("keeps interactive controls for players after the public-body refactor", () => {
+    const view = render(
+      <QuestionActivePhase
+        state={state}
+        hasSubmitted={false}
+        selectedIndices={[]}
+        answer=""
+        setAnswer={vi.fn()}
+        toggleIndex={vi.fn()}
+        submitAnswer={vi.fn()}
+        submissionStatus="idle"
+      />,
+    );
+
+    expect(
+      view.container.querySelector('[data-testid="player-choice-0"]'),
+    ).not.toBeNull();
+    expect(
+      view.container.querySelector('[data-testid="player-submit-answer"]'),
+    ).not.toBeNull();
+
+    view.unmount();
+  });
+});

--- a/apps/client/src/components/player/QuestionActivePhase.tsx
+++ b/apps/client/src/components/player/QuestionActivePhase.tsx
@@ -1,25 +1,11 @@
 import React from "react";
-import { Send, CheckCircle, XCircle } from "lucide-react";
+import { CheckCircle, XCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { Card } from "../ui/Card";
-import Button from "../ui/Button";
-import Input from "../ui/Input";
-import Badge from "../ui/Badge";
-import { CrosswordPlayer } from "./CrosswordPlayer";
-import { FillInTheBlanksPlayer } from "./FillInTheBlanksPlayer";
-import { MatchingPlayer } from "./MatchingPlayer";
-import { ChronologyPlayer } from "./ChronologyPlayer";
-import TrueFalsePlayer from "./TrueFalsePlayer";
-import CorrectTheErrorPlayer from "./CorrectTheErrorPlayer";
-import { isChronologyAnswer } from "../../utils/answerGuards";
 import type { 
   GameState, 
-  AnswerContent, 
-  MultipleChoiceContent, 
-  ChronologyContent, 
-  MatchingContent, 
-  CorrectTheErrorAnswer 
+  AnswerContent
 } from "@quizco/shared";
+import { PublicQuestionBody } from "./PublicQuestionBody";
 
 interface QuestionActivePhaseProps {
   state: GameState;
@@ -51,218 +37,19 @@ export const QuestionActivePhase: React.FC<QuestionActivePhaseProps> = ({
 
   return (
     <div className="w-full max-w-3xl space-y-8">
-      {currentQuestion.section && (
-        <Badge
-          variant="yellow"
-          className="p-4 rounded-2xl border-2 border-yellow-400 text-2xl"
-        >
-          {t("player.turn")}: {currentQuestion.section}
-        </Badge>
-      )}
       {!hasSubmitted ? (
-        <div className="space-y-8 text-left">
-          <Card className="p-8 border-b-4 border-blue-500">
-            <span className="text-blue-600 font-bold uppercase tracking-wider text-sm">
-              {t("common.question") || "Question"}
-            </span>
-            <h2
-              className="text-2xl md:text-3xl font-bold mt-2 text-gray-800"
-              data-testid="player-active-question-text"
-            >
-              {currentQuestion.questionText}
-            </h2>
-          </Card>
-          <div className="space-y-6 w-full">
-            {currentQuestion.type === "MULTIPLE_CHOICE" ? (
-              <div className="space-y-6">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {(currentQuestion.content as MultipleChoiceContent)?.options?.map(
-                    (opt: string, i: number) => {
-                      const isSelected = selectedIndices.includes(i);
-                      return (
-                        <button
-                          key={i}
-                          onClick={() => toggleIndex(i)}
-                          data-testid={`player-choice-${i}`}
-                          className={`border-4 p-6 rounded-2xl text-xl font-black transition-all transform active:scale-95 text-left flex items-center justify-between ${
-                            isSelected
-                              ? "bg-blue-600 border-blue-400 text-white shadow-lg translate-y-[-2px]"
-                              : "bg-white border-gray-100 text-gray-700 hover:border-blue-200"
-                          }`}
-                        >
-                          <span>{opt}</span>
-                          {isSelected && (
-                            <CheckCircle className="w-6 h-6 text-white" />
-                          )}
-                        </button>
-                      );
-                    }
-                  )}
-                </div>
-                <Button
-                  variant="primary"
-                  onClick={() => submitAnswer(selectedIndices, true)}
-                  disabled={selectedIndices.length === 0}
-                  size="xl"
-                  data-testid="player-submit-answer"
-                  className={`w-full ${
-                    selectedIndices.length > 0 ? "translate-y-[-4px]" : ""
-                  }`}
-                >
-                  <Send className="w-8 h-8 mr-3" />
-                  <span>{t("player.submit_answer")}</span>
-                </Button>
-              </div>
-            ) : currentQuestion.type === "CROSSWORD" ? (
-              <div className="bg-white p-4 rounded-xl shadow-inner max-h-[60vh] overflow-auto">
-                <CrosswordPlayer
-                  data={currentQuestion.content}
-                  value={answer as string[][]}
-                  onChange={(grid) => {
-                    setAnswer(grid);
-                  }}
-                  onSubmit={(grid) => {
-                    submitAnswer(grid, true);
-                  }}
-                />
-              </div>
-            ) : currentQuestion.type === "FILL_IN_THE_BLANKS" ? (
-              <div className="space-y-6">
-                <FillInTheBlanksPlayer
-                  content={currentQuestion.content}
-                  value={(answer as string[]) || []}
-                  onChange={(val) => setAnswer(val)}
-                />
-                <Button
-                  onClick={() => submitAnswer(answer, true)}
-                  data-testid="player-submit-answer"
-                  className="w-full py-6 rounded-3xl text-3xl shadow-xl"
-                >
-                  <Send className="w-8 h-8 mr-2" />{" "}
-                  <span>{t("player.submit_answer")}</span>
-                </Button>
-              </div>
-            ) : currentQuestion.type === "MATCHING" ? (
-              <div className="space-y-6">
-                <MatchingPlayer
-                  content={currentQuestion.content}
-                  value={(answer as Record<string, string>) || {}}
-                  onChange={(val) => setAnswer(val)}
-                />
-                <Button
-                  onClick={() => submitAnswer(answer, true)}
-                  disabled={
-                    Object.keys(answer || {}).length <
-                    (currentQuestion.content as MatchingContent).pairs.length
-                  }
-                  data-testid="player-submit-answer"
-                  className="w-full py-6 rounded-3xl text-3xl shadow-xl"
-                >
-                  <Send className="w-8 h-8 mr-2" />{" "}
-                  <span>{t("player.submit_answer")}</span>
-                </Button>
-              </div>
-            ) : currentQuestion.type === "CHRONOLOGY" ? (
-              <div className="space-y-6">
-                <ChronologyPlayer
-                  key={currentQuestion.id}
-                  content={currentQuestion.content}
-                  value={
-                    isChronologyAnswer(answer)
-                      ? answer
-                      : {
-                          slotIds: (currentQuestion.content as ChronologyContent).items.map(
-                            () => null
-                          ),
-                          poolIds: (currentQuestion.content as ChronologyContent).items.map(
-                            (item) => item.id
-                          ),
-                        }
-                  }
-                  onChange={(val) => setAnswer(val)}
-                />
-                <Button
-                  onClick={() => submitAnswer(answer, true)}
-                  data-testid="player-submit-answer"
-                  className="w-full py-6 rounded-3xl text-3xl shadow-xl"
-                >
-                  <Send className="w-8 h-8 mr-2" />{" "}
-                  <span>{t("player.submit_answer")}</span>
-                </Button>
-              </div>
-            ) : currentQuestion.type === "TRUE_FALSE" ? (
-              <div className="space-y-6">
-                <TrueFalsePlayer
-                  selectedAnswer={answer as boolean | null}
-                  disabled={hasSubmitted}
-                  onAnswer={(val) => {
-                    setAnswer(val);
-                  }}
-                />
-                <Button
-                  onClick={() => submitAnswer(answer, true)}
-                  disabled={answer === null}
-                  data-testid="player-submit-answer"
-                  className="w-full py-6 rounded-3xl text-3xl shadow-xl"
-                >
-                  <Send className="w-8 h-8 mr-2" />{" "}
-                  <span>{t("player.submit_answer")}</span>
-                </Button>
-              </div>
-            ) : currentQuestion.type === "CORRECT_THE_ERROR" ? (
-              <div className="space-y-6">
-                <CorrectTheErrorPlayer
-                  content={currentQuestion.content}
-                  value={
-                    (answer as CorrectTheErrorAnswer) || {
-                      selectedPhraseIndex: -1,
-                      correction: "",
-                    }
-                  }
-                  onChange={(val) => setAnswer(val)}
-                  disabled={hasSubmitted}
-                />
-                {!hasSubmitted && (
-                  <Button
-                    onClick={() => submitAnswer(answer, true)}
-                    disabled={
-                      (answer as CorrectTheErrorAnswer).selectedPhraseIndex ===
-                        -1 || !(answer as CorrectTheErrorAnswer).correction
-                    }
-                    data-testid="player-submit-answer"
-                    className="w-full py-6 rounded-3xl text-3xl shadow-xl"
-                  >
-                    <Send className="w-8 h-8 mr-2" />{" "}
-                    <span>{t("player.submit_answer")}</span>
-                  </Button>
-                )}
-              </div>
-            ) : (
-              <div className="flex flex-col space-y-4">
-                <Input
-                  type="text"
-                  value={String(answer)}
-                  onChange={(e) => setAnswer(e.target.value)}
-                  onKeyDown={(e) =>
-                    e.key === "Enter" && submitAnswer(answer, true)
-                  }
-                  className="text-2xl"
-                  placeholder="Type your answer..."
-                  data-testid="player-open-answer-input"
-                />
-                <Button
-                  onClick={() => submitAnswer(answer, true)}
-                  size="lg"
-                  data-testid="player-submit-answer"
-                  className="shadow-lg"
-                >
-                  <Send className="mr-2" />{" "}
-                  <span>{t("player.submit_answer")}</span>
-                </Button>
-              </div>
-            )}
-          </div>
-        </div>
+        <PublicQuestionBody
+          mode="interactive"
+          state={state}
+          hasSubmitted={hasSubmitted}
+          selectedIndices={selectedIndices}
+          answer={answer}
+          setAnswer={setAnswer}
+          toggleIndex={toggleIndex}
+          submitAnswer={submitAnswer}
+          submissionStatus={submissionStatus}
+          currentTeam={currentTeam}
+        />
       ) : (
         <div
           className={`p-8 rounded-2xl border-2 ${

--- a/apps/client/src/components/player/questionText.test.ts
+++ b/apps/client/src/components/player/questionText.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import type { Question } from "@quizco/shared";
+import i18n from "../../i18n";
+import { getQuestionCorrectAnswer } from "./questionText";
+
+const t = i18n.t.bind(i18n);
+
+describe("getQuestionCorrectAnswer", () => {
+  it("formats multiple-choice and closed answers", () => {
+    const multipleChoiceQuestion: Question = {
+      id: "q-mc",
+      roundId: "round-1",
+      questionText: "Pick all that apply",
+      type: "MULTIPLE_CHOICE",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        options: ["Alpha", "Beta", "Gamma"],
+        correctIndices: [0, 2],
+      },
+    };
+
+    const closedQuestion: Question = {
+      id: "q-closed",
+      roundId: "round-1",
+      questionText: "Closed",
+      type: "CLOSED",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        options: ["Closed answer"],
+      },
+    };
+
+    expect(getQuestionCorrectAnswer(multipleChoiceQuestion, t)).toBe(
+      "Alpha, Gamma",
+    );
+    expect(getQuestionCorrectAnswer(closedQuestion, t)).toBe("Closed answer");
+  });
+
+  it("formats text-based question answers", () => {
+    const openWordQuestion: Question = {
+      id: "q-open",
+      roundId: "round-1",
+      questionText: "Open",
+      type: "OPEN_WORD",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        answer: "Mercy",
+      },
+    };
+
+    const trueFalseQuestion: Question = {
+      id: "q-true-false",
+      roundId: "round-1",
+      questionText: "True or false",
+      type: "TRUE_FALSE",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        isTrue: false,
+      },
+    };
+
+    const correctTheErrorQuestion: Question = {
+      id: "q-cte",
+      roundId: "round-1",
+      questionText: "Correct the error",
+      type: "CORRECT_THE_ERROR",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        text: "This phrase is good",
+        phrases: [
+          {
+            text: "was",
+            alternatives: ["were", "is"],
+          },
+          {
+            text: "good",
+            alternatives: ["bad", "better"],
+          },
+        ],
+        errorPhraseIndex: 1,
+        correctReplacement: "better",
+      },
+    };
+
+    expect(getQuestionCorrectAnswer(openWordQuestion, t)).toBe("Mercy");
+    expect(getQuestionCorrectAnswer(trueFalseQuestion, t)).toBe("False");
+    expect(getQuestionCorrectAnswer(correctTheErrorQuestion, t)).toBe(
+      "good -> better",
+    );
+  });
+
+  it("formats structured question answers", () => {
+    const fillInTheBlanksQuestion: Question = {
+      id: "q-fill",
+      roundId: "round-1",
+      questionText: "Fill in the blanks",
+      type: "FILL_IN_THE_BLANKS",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        text: "___ and ___",
+        blanks: [
+          {
+            options: [
+              { value: "Hope", isCorrect: false },
+              { value: "Faith", isCorrect: true },
+            ],
+          },
+          {
+            options: [{ value: "Love", isCorrect: true }],
+          },
+        ],
+      },
+    };
+
+    const matchingQuestion: Question = {
+      id: "q-match",
+      roundId: "round-1",
+      questionText: "Match",
+      type: "MATCHING",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        pairs: [
+          { id: "pair-1", left: "Paul", right: "Apostle" },
+          { id: "pair-2", left: "David", right: "King" },
+        ],
+      },
+    };
+
+    const chronologyQuestion: Question = {
+      id: "q-chrono",
+      roundId: "round-1",
+      questionText: "Order the events",
+      type: "CHRONOLOGY",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        items: [
+          { id: "item-2", text: "Second", order: 1 },
+          { id: "item-1", text: "First", order: 0 },
+          { id: "item-3", text: "Third", order: 2 },
+        ],
+      },
+    };
+
+    const crosswordQuestion: Question = {
+      id: "q-crossword",
+      roundId: "round-1",
+      questionText: "Crossword",
+      type: "CROSSWORD",
+      points: 10,
+      timeLimitSeconds: 30,
+      grading: "AUTO",
+      content: {
+        grid: [["A"]],
+        clues: {
+          across: [],
+          down: [],
+        },
+      },
+    };
+
+    expect(getQuestionCorrectAnswer(fillInTheBlanksQuestion, t)).toBe(
+      "Faith, Love",
+    );
+    expect(getQuestionCorrectAnswer(matchingQuestion, t)).toBe(
+      "Paul -> Apostle | David -> King",
+    );
+    expect(getQuestionCorrectAnswer(chronologyQuestion, t)).toBe(
+      "First -> Second -> Third",
+    );
+    expect(getQuestionCorrectAnswer(crosswordQuestion, t)).toBe(
+      i18n.t("player.see_grid"),
+    );
+  });
+});

--- a/apps/client/src/components/player/questionText.ts
+++ b/apps/client/src/components/player/questionText.ts
@@ -1,0 +1,60 @@
+import type {
+  ChronologyContent,
+  CorrectTheErrorContent,
+  FillInTheBlanksContent,
+  MatchingContent,
+  Question,
+  TrueFalseContent,
+} from "@quizco/shared";
+import type { TFunction } from "i18next";
+
+export function getQuestionCorrectAnswer(question: Question, t: TFunction): string {
+  const { type, content } = question;
+
+  if (type === "MULTIPLE_CHOICE") {
+    return content.correctIndices.map((idx) => content.options[idx]).join(", ") || "Unknown";
+  }
+
+  if (type === "CLOSED") {
+    return content.options[0] || "Unknown";
+  }
+
+  if (type === "OPEN_WORD") {
+    return content.answer;
+  }
+
+  if (type === "CROSSWORD") {
+    return t("player.see_grid");
+  }
+
+  if (type === "FILL_IN_THE_BLANKS") {
+    return (content as FillInTheBlanksContent).blanks
+      .map((blank) => blank.options.find((option) => option.isCorrect)?.value || "??")
+      .join(", ");
+  }
+
+  if (type === "MATCHING") {
+    return (content as MatchingContent).pairs
+      .map((pair) => `${pair.left} -> ${pair.right}`)
+      .join(" | ");
+  }
+
+  if (type === "CHRONOLOGY") {
+    return [...(content as ChronologyContent).items]
+      .sort((a, b) => a.order - b.order)
+      .map((item) => item.text)
+      .join(" -> ");
+  }
+
+  if (type === "TRUE_FALSE") {
+    return (content as TrueFalseContent).isTrue ? t("game.true") : t("game.false");
+  }
+
+  if (type === "CORRECT_THE_ERROR") {
+    const correctTheErrorContent = content as CorrectTheErrorContent;
+    const errorPhrase = correctTheErrorContent.phrases[correctTheErrorContent.errorPhraseIndex];
+    return `${errorPhrase.text} -> ${correctTheErrorContent.correctReplacement}`;
+  }
+
+  return "Unknown";
+}

--- a/apps/client/src/locales/bg.json
+++ b/apps/client/src/locales/bg.json
@@ -138,7 +138,8 @@
     "audience": {
       "title": "Изглед за Публиката",
       "answer_summary": "Обобщение на Отговорите",
-      "correct_count": "{{correct}}/{{total}} отбора с верен отговор ({{percentage}}%)"
+      "correct_count": "{{correct}}/{{total}} отбора с верен отговор ({{percentage}}%)",
+      "open_answer_hidden": "Публиката ще види правилния отговор след разкриването"
     },
     "game": {
       "true": "Истина",

--- a/apps/client/src/locales/bg.json
+++ b/apps/client/src/locales/bg.json
@@ -135,6 +135,11 @@
         }
       }
     },
+    "audience": {
+      "title": "Изглед за Публиката",
+      "answer_summary": "Обобщение на Отговорите",
+      "correct_count": "{{correct}}/{{total}} отбора с верен отговор ({{percentage}}%)"
+    },
     "game": {
       "true": "Истина",
       "false": "Лъжа",

--- a/apps/client/src/locales/en.json
+++ b/apps/client/src/locales/en.json
@@ -138,7 +138,8 @@
     "audience": {
       "title": "Audience View",
       "answer_summary": "Answer Summary",
-      "correct_count": "{{correct}}/{{total}} teams correct ({{percentage}}%)"
+      "correct_count": "{{correct}}/{{total}} teams correct ({{percentage}}%)",
+      "open_answer_hidden": "Audience will see the correct answer after reveal"
     },
     "game": {
       "true": "True",

--- a/apps/client/src/locales/en.json
+++ b/apps/client/src/locales/en.json
@@ -135,6 +135,11 @@
         }
       }
     },
+    "audience": {
+      "title": "Audience View",
+      "answer_summary": "Answer Summary",
+      "correct_count": "{{correct}}/{{total}} teams correct ({{percentage}}%)"
+    },
     "game": {
       "true": "True",
       "false": "False",

--- a/apps/client/src/test/render.tsx
+++ b/apps/client/src/test/render.tsx
@@ -1,0 +1,47 @@
+import { act } from "react";
+import type { ReactElement } from "react";
+import { createRoot } from "react-dom/client";
+
+interface RenderResult {
+  container: HTMLDivElement;
+  rerender: (ui: ReactElement) => void;
+  unmount: () => void;
+}
+
+export function render(ui: ReactElement): RenderResult {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(ui);
+  });
+
+  return {
+    container,
+    rerender(nextUi: ReactElement) {
+      act(() => {
+        root.render(nextUi);
+      });
+    },
+    unmount() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+export async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+export function click(element: HTMLElement): void {
+  act(() => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}

--- a/apps/client/src/test/setup.ts
+++ b/apps/client/src/test/setup.ts
@@ -1,0 +1,16 @@
+import { afterEach, beforeEach, vi } from "vitest";
+import i18n from "../i18n";
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  value: true,
+  writable: true,
+});
+
+beforeEach(async () => {
+  await i18n.changeLanguage("en");
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});

--- a/apps/client/tsconfig.node.json
+++ b/apps/client/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/test/setup.ts",
+  },
+});

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const shouldManageWebServers = process.env.PW_SKIP_WEBSERVER !== "1";
+
 export default defineConfig({
   testDir: "./tests",
   outputDir: "./test-results/artifacts",
@@ -20,22 +22,24 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   globalSetup: "./global-setup.ts",
-  webServer: [
-    {
-      command: "npm run dev -w @quizco/server",
-      cwd: "../..",
-      url: "http://127.0.0.1:4000/api/competitions",
-      timeout: 120_000,
-      reuseExistingServer: !process.env.CI,
-    },
-    {
-      command: "npm run dev -w client -- --host 127.0.0.1 --port 4173",
-      cwd: "../..",
-      url: "http://127.0.0.1:4173",
-      timeout: 120_000,
-      reuseExistingServer: !process.env.CI,
-    },
-  ],
+  webServer: shouldManageWebServers
+    ? [
+        {
+          command: "npm run dev -w @quizco/server",
+          cwd: "../..",
+          url: "http://127.0.0.1:4000/api/competitions",
+          timeout: 120_000,
+          reuseExistingServer: !process.env.CI,
+        },
+        {
+          command: "npm run dev -w client -- --host 127.0.0.1 --port 4173",
+          cwd: "../..",
+          url: "http://127.0.0.1:4173",
+          timeout: 120_000,
+          reuseExistingServer: !process.env.CI,
+        },
+      ]
+    : undefined,
   projects: [
     {
       name: "chromium",

--- a/apps/e2e/tests/audience-view.spec.ts
+++ b/apps/e2e/tests/audience-view.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+import {
+  clickHostNextAndExpectPhase,
+  createAdminApi,
+  createCompetitionWithQuestions,
+  createHostAndPlayers,
+  deleteCompetition,
+  moveToQuestionPreview,
+} from "./helpers/gameHarness";
+
+let competitionId = "";
+
+test.beforeAll(async () => {
+  const adminApi = await createAdminApi();
+  const fixture = await createCompetitionWithQuestions(adminApi, "Audience View", [
+    {
+      questionText: "Audience multiple choice question",
+      type: "MULTIPLE_CHOICE",
+      content: {
+        options: ["Wrong answer", "Correct answer"],
+        correctIndices: [1],
+      },
+    },
+  ]);
+  competitionId = fixture.competitionId;
+  await adminApi.dispose();
+});
+
+test.afterAll(async () => {
+  if (!competitionId) {
+    return;
+  }
+
+  const adminApi = await createAdminApi();
+  await deleteCompetition(adminApi, competitionId);
+  await adminApi.dispose();
+});
+
+test("audience view mirrors public question flow and reveal stats", async ({ browser }) => {
+  const sessions = await createHostAndPlayers(
+    browser,
+    competitionId,
+    "Audience Team One",
+    "Audience Team Two",
+  );
+
+  const audienceContext = await browser.newContext();
+  const audiencePage = await audienceContext.newPage();
+
+  await audiencePage.goto("/audience");
+  await audiencePage.getByTestId(`competition-option-${competitionId}`).click();
+  await expect(audiencePage.getByTestId("audience-phase")).toHaveText("WAITING");
+
+  await moveToQuestionPreview(sessions.hostPage);
+
+  await expect(audiencePage.getByTestId("audience-phase")).toHaveText("QUESTION_PREVIEW", {
+    timeout: 20_000,
+  });
+
+  await clickHostNextAndExpectPhase(sessions.hostPage, "QUESTION_PREVIEW");
+  await expect(audiencePage.getByTestId("audience-preview-option-0")).toContainText("Wrong answer");
+  await expect(audiencePage.getByTestId("audience-preview-option-1")).toHaveCount(0);
+
+  await clickHostNextAndExpectPhase(sessions.hostPage, "QUESTION_PREVIEW");
+  await expect(audiencePage.getByTestId("audience-preview-option-1")).toContainText("Correct answer");
+
+  await clickHostNextAndExpectPhase(sessions.hostPage, "QUESTION_ACTIVE");
+  await expect(audiencePage.getByTestId("audience-phase")).toHaveText("QUESTION_ACTIVE", {
+    timeout: 20_000,
+  });
+  await expect(audiencePage.getByTestId("audience-choice-0")).toContainText("Wrong answer");
+  await expect(audiencePage.getByTestId("audience-choice-1")).toContainText("Correct answer");
+  await expect(audiencePage.getByTestId("player-submit-answer")).toHaveCount(0);
+
+  await sessions.playerOnePage.getByTestId("player-choice-1").click();
+  await sessions.playerOnePage.getByTestId("player-submit-answer").click();
+  await sessions.playerTwoPage.getByTestId("player-choice-0").click();
+  await sessions.playerTwoPage.getByTestId("player-submit-answer").click();
+
+  await expect(sessions.hostPage.getByTestId("host-current-phase")).toHaveText("GRADING", {
+    timeout: 20_000,
+  });
+
+  await clickHostNextAndExpectPhase(sessions.hostPage, "REVEAL_ANSWER");
+
+  await expect(audiencePage.getByTestId("audience-phase")).toHaveText("REVEAL_ANSWER", {
+    timeout: 20_000,
+  });
+  await expect(audiencePage.getByTestId("audience-answer-stats")).toContainText(
+    "1/2 teams correct (50%)",
+  );
+  await expect(audiencePage.locator("text=Correct answer")).toBeVisible();
+
+  await audienceContext.close();
+  await sessions.close();
+});

--- a/apps/e2e/tests/audience-view.spec.ts
+++ b/apps/e2e/tests/audience-view.spec.ts
@@ -125,6 +125,7 @@ test("audience view mirrors public question flow and reveal stats", async ({ bro
   await expect(audiencePage.getByTestId("audience-answer-stats")).toContainText(
     "1/2 teams correct (50%)",
   );
+  await expect(audiencePage.getByText("Your Choice")).toHaveCount(0);
   await expect(audiencePage.locator("text=Correct answer")).toBeVisible();
 
   await clickHostNextAndExpectPhase(sessions.hostPage, "QUESTION_PREVIEW");

--- a/apps/e2e/tests/audience-view.spec.ts
+++ b/apps/e2e/tests/audience-view.spec.ts
@@ -21,6 +21,35 @@ test.beforeAll(async () => {
         correctIndices: [1],
       },
     },
+    {
+      questionText: "Audience crossword question",
+      type: "CROSSWORD",
+      content: {
+        grid: [["A", "B"], ["", "C"]],
+        clues: {
+          across: [
+            {
+              number: 1,
+              x: 0,
+              y: 0,
+              direction: "across",
+              clue: "Audience across clue",
+              answer: "AB",
+            },
+          ],
+          down: [
+            {
+              number: 2,
+              x: 1,
+              y: 0,
+              direction: "down",
+              clue: "Audience down clue",
+              answer: "BC",
+            },
+          ],
+        },
+      },
+    },
   ]);
   competitionId = fixture.competitionId;
   await adminApi.dispose();
@@ -49,7 +78,14 @@ test("audience view mirrors public question flow and reveal stats", async ({ bro
 
   await audiencePage.goto("/audience");
   await audiencePage.getByTestId(`competition-option-${competitionId}`).click();
+  await expect(audiencePage).toHaveURL(new RegExp(`\\/audience\\?competitionId=${competitionId}$`));
   await expect(audiencePage.getByTestId("audience-phase")).toHaveText("WAITING");
+
+  const deepLinkedAudienceContext = await browser.newContext();
+  const deepLinkedAudiencePage = await deepLinkedAudienceContext.newPage();
+  await deepLinkedAudiencePage.goto(`/audience?competitionId=${competitionId}`);
+  await expect(deepLinkedAudiencePage.getByTestId("audience-phase")).toHaveText("WAITING");
+  await deepLinkedAudienceContext.close();
 
   await moveToQuestionPreview(sessions.hostPage);
 
@@ -90,6 +126,28 @@ test("audience view mirrors public question flow and reveal stats", async ({ bro
     "1/2 teams correct (50%)",
   );
   await expect(audiencePage.locator("text=Correct answer")).toBeVisible();
+
+  await clickHostNextAndExpectPhase(sessions.hostPage, "QUESTION_PREVIEW");
+  await expect(audiencePage.getByTestId("audience-phase")).toHaveText("QUESTION_PREVIEW", {
+    timeout: 20_000,
+  });
+
+  await clickHostNextAndExpectPhase(sessions.hostPage, "QUESTION_ACTIVE");
+
+  await expect(audiencePage.getByTestId("audience-phase")).toHaveText("QUESTION_ACTIVE", {
+    timeout: 20_000,
+  });
+  await expect(audiencePage.getByTestId("audience-active-question-text")).toHaveText(
+    "Audience crossword question",
+  );
+  await expect(audiencePage.getByTestId("audience-crossword")).toBeVisible();
+  await expect(audiencePage.getByTestId("audience-crossword-across-0")).toContainText(
+    "Audience across clue",
+  );
+  await expect(audiencePage.getByTestId("audience-crossword-down-0")).toContainText(
+    "Audience down clue",
+  );
+  await expect(audiencePage.getByTestId("crossword-submit")).toHaveCount(0);
 
   await audienceContext.close();
   await sessions.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.0.1",
         "postcss": "^8.5.6",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
@@ -246,6 +247,67 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -538,6 +600,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -560,6 +635,146 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -1226,6 +1441,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -2887,6 +3120,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3394,6 +3637,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3413,6 +3670,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3429,6 +3700,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3653,6 +3931,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -4488,6 +4779,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -4690,6 +4994,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4724,6 +5035,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -5138,6 +5500,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -5499,6 +5868,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -6208,6 +6590,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -6355,6 +6747,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -6728,6 +7133,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -6828,6 +7240,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6847,6 +7279,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -7150,6 +7608,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -8441,6 +8909,54 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8511,6 +9027,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",


### PR DESCRIPTION
- Added AudienceRevealPhase component to display the correct answer and audience stats during the reveal phase.
- Created AudienceView component to manage audience interactions and display competition details.
- Implemented audienceStats utility to calculate and display audience answer statistics.
- Developed tests for AudienceView, AudienceRevealPhase, and audienceStats to ensure functionality.
- Updated PublicQuestionBody and PublicQuestionPreview components to support new audience features.
- Added e2e tests for audience view to validate the flow from question preview to answer reveal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audience View for spectators with competition deep-linking, synchronized phase updates, progressive previews, reveal screens, and read-only support (including crossword audience rendering).
  * Public-facing question preview/body components for consistent spectator display.

* **Refactor**
  * Centralized public question rendering to simplify player-facing UI and reuse preview/reveal logic.

* **Tests**
  * Extensive unit and end-to-end tests covering audience flows, public question UI, and answer-stat calculations.

* **Localization**
  * Added audience translations (en, bg).

* **Chores**
  * Test tooling configured for jsdom and Vitest setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->