### PR TITLE
Fix player session autosave and reconnect handling

### DIFF
--- a/apps/client/src/components/player/PublicQuestionBody.tsx
+++ b/apps/client/src/components/player/PublicQuestionBody.tsx
@@ -8,15 +8,17 @@ import {
 } from "./questionRenderers";
 import { AnalogueTimer } from "./AnalogueTimer";
 
+type PlayerDraftAnswer = AnswerContent | null;
+
 interface InteractivePublicQuestionBodyProps {
   mode: "interactive";
   state: GameState;
   hasSubmitted: boolean;
   selectedIndices: number[];
-  answer: AnswerContent;
-  setAnswer: (value: AnswerContent) => void;
+  answer: PlayerDraftAnswer;
+  setAnswer: (value: PlayerDraftAnswer) => void;
   toggleIndex: (index: number) => void;
-  submitAnswer: (value: AnswerContent, isFinal?: boolean) => void;
+  submitAnswer: (value: PlayerDraftAnswer, isFinal?: boolean) => void;
   requestJoker?: () => void;
   testIdPrefix?: string;
 }

--- a/apps/client/src/components/player/phases/QuestionActivePhase.tsx
+++ b/apps/client/src/components/player/phases/QuestionActivePhase.tsx
@@ -4,14 +4,16 @@ import type { AnswerContent, GameState } from "@quizco/shared";
 import { useTranslation } from "react-i18next";
 import { PublicQuestionBody } from "../PublicQuestionBody";
 
+type PlayerDraftAnswer = AnswerContent | null;
+
 interface QuestionActivePhaseProps {
   state: GameState;
   hasSubmitted: boolean;
   selectedIndices: number[];
-  answer: AnswerContent;
-  setAnswer: (val: AnswerContent) => void;
+  answer: PlayerDraftAnswer;
+  setAnswer: (val: PlayerDraftAnswer) => void;
   toggleIndex: (index: number) => void;
-  submitAnswer: (value: AnswerContent, isFinal?: boolean) => void;
+  submitAnswer: (value: PlayerDraftAnswer, isFinal?: boolean) => void;
   submissionStatus: "idle" | "success" | "error";
   currentTeam?: { isExplicitlySubmitted?: boolean };
   requestJoker?: () => void;

--- a/apps/client/src/components/player/questionRenderers.tsx
+++ b/apps/client/src/components/player/questionRenderers.tsx
@@ -36,6 +36,8 @@ import { DefaultReveal } from "./questions/DefaultReveal";
 import { isChronologyAnswer, isStringGrid } from "../../utils/answerGuards";
 import { getQuestionCorrectAnswer } from "./questionText";
 
+type PlayerDraftAnswer = AnswerContent | null;
+
 export interface QuestionPreviewRendererContext {
   question: Question;
   revealStep: number;
@@ -45,12 +47,12 @@ export interface QuestionPreviewRendererContext {
 
 export interface InteractiveQuestionRendererContext {
   question: Question;
-  answer: AnswerContent;
+  answer: PlayerDraftAnswer;
   selectedIndices: number[];
   hasSubmitted: boolean;
-  setAnswer: (value: AnswerContent) => void;
+  setAnswer: (value: PlayerDraftAnswer) => void;
   toggleIndex: (index: number) => void;
-  submitAnswer: (value: AnswerContent, isFinal?: boolean) => void;
+  submitAnswer: (value: PlayerDraftAnswer, isFinal?: boolean) => void;
   testIdPrefix: string;
   requestJoker?: () => void;
   t: TFunction;
@@ -519,7 +521,7 @@ const questionRenderers: Record<QuestionType, QuestionRenderer> = {
       <div className="flex flex-col space-y-4">
         <Input
           type="text"
-          value={String(answer)}
+          value={typeof answer === "string" ? answer : ""}
           onChange={(event) => setAnswer(event.target.value)}
           onKeyDown={(event) => event.key === "Enter" && submitAnswer(answer, true)}
           className="text-2xl"
@@ -565,7 +567,7 @@ const questionRenderers: Record<QuestionType, QuestionRenderer> = {
       <div className="flex flex-col space-y-4">
         <Input
           type="text"
-          value={String(answer)}
+          value={typeof answer === "string" ? answer : ""}
           onChange={(event) => setAnswer(event.target.value)}
           onKeyDown={(event) => event.key === "Enter" && submitAnswer(answer, true)}
           className="text-2xl"

--- a/apps/client/src/hooks/testUtils.tsx
+++ b/apps/client/src/hooks/testUtils.tsx
@@ -20,10 +20,15 @@ export function renderHook<T>(useHook: () => T, options?: RenderHookOptions) {
   }
 
   const hookUi = <Harness />;
-  const view = render(options?.wrapper ? options.wrapper({ children: hookUi }) : hookUi);
+  const buildHookUi = () =>
+    options?.wrapper ? options.wrapper({ children: hookUi }) : hookUi;
+  const view = render(buildHookUi());
 
   return {
     ...view,
+    rerender() {
+      view.rerender(buildHookUi());
+    },
     get result(): T {
       return resultRef.current!;
     },

--- a/apps/client/src/hooks/usePlayerSession.test.tsx
+++ b/apps/client/src/hooks/usePlayerSession.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GameState } from "@quizco/shared";
 import { flushEffects } from "../test/render";
 import { renderHook } from "./testUtils";
@@ -53,6 +53,7 @@ const baseState: GameState = {
 
 describe("usePlayerSession", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     const storage = new Map<string, string>();
     Object.defineProperty(window, "localStorage", {
       configurable: true,
@@ -75,6 +76,10 @@ describe("usePlayerSession", () => {
       "fetch",
       vi.fn(async () => ({ json: async () => [] }) as Response),
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("uses the persisted teamId as the stable identity key after reconnect", async () => {
@@ -141,6 +146,275 @@ describe("usePlayerSession", () => {
 
     expect(hook.result.answer).toBe("answer");
     expect(hook.result.submissionStatus).toBe("idle");
+    hook.unmount();
+  });
+
+  it("does not reconnect after a fresh join writes localStorage", async () => {
+    emit.mockImplementation((event, _payload, callback) => {
+      if (event === "JOIN_ROOM") {
+        callback?.({
+          success: true,
+          team: { id: "team-new", name: "Fresh Team", color: "#123456" },
+        });
+      }
+    });
+
+    const hook = renderHook(() => usePlayerSession(baseState));
+    await flushEffects();
+
+    hook.act(() => {
+      hook.result.selectCompetition("competition-1");
+      hook.result.setTeamName("Fresh Team");
+      hook.result.setColor("#123456");
+    });
+    await flushEffects();
+
+    hook.act(() => {
+      hook.result.joinTeam();
+    });
+    await flushEffects();
+
+    expect(emit).toHaveBeenCalledWith(
+      "JOIN_ROOM",
+      {
+        competitionId: "competition-1",
+        teamName: "Fresh Team",
+        color: "#123456",
+      },
+      expect.any(Function),
+    );
+    expect(emit).not.toHaveBeenCalledWith(
+      "RECONNECT_TEAM",
+      expect.anything(),
+      expect.any(Function),
+    );
+    expect(hook.result.joined).toBe(true);
+    hook.unmount();
+  });
+
+  it("keeps untouched true/false answers as explicit null draft state", async () => {
+    window.localStorage.setItem("quizco_team_id", "team-1");
+
+    const questionState: GameState = {
+      ...baseState,
+      currentQuestion: {
+        id: "question-true-false-1",
+        roundId: "round-1",
+        questionText: "True or false",
+        type: "TRUE_FALSE",
+        points: 1,
+        timeLimitSeconds: 30,
+        grading: "AUTO",
+        content: { isTrue: true },
+      },
+    };
+
+    const hook = renderHook(() => usePlayerSession(questionState));
+    await flushEffects();
+
+    expect(hook.result.answer).toBeNull();
+    hook.unmount();
+  });
+
+  it("does not autosave untouched chronology defaults", async () => {
+    window.localStorage.setItem("quizco_team_id", "team-1");
+    window.localStorage.setItem("quizco_selected_competition_id", "competition-1");
+
+    emit.mockImplementation((event, _payload, callback) => {
+      if (event === "RECONNECT_TEAM") {
+        callback?.({
+          success: true,
+          team: { id: "team-1", name: "Alpha", color: "#111111" },
+        });
+      }
+    });
+
+    const questionState: GameState = {
+      ...baseState,
+      phase: "QUESTION_ACTIVE",
+      currentQuestion: {
+        id: "question-chronology-empty",
+        roundId: "round-1",
+        questionText: "Put these in order",
+        type: "CHRONOLOGY",
+        points: 10,
+        timeLimitSeconds: 30,
+        grading: "AUTO",
+        content: {
+          items: [
+            { id: "c1", text: "First", order: 0 },
+            { id: "c2", text: "Second", order: 1 },
+          ],
+        },
+      },
+    };
+
+    const hook = renderHook(() => usePlayerSession(questionState));
+    await flushEffects();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(emit.mock.calls.filter(([event]) => event === "SUBMIT_ANSWER")).toHaveLength(0);
+    hook.unmount();
+  });
+
+  it("does not autosave untouched crossword grids", async () => {
+    window.localStorage.setItem("quizco_team_id", "team-1");
+    window.localStorage.setItem("quizco_selected_competition_id", "competition-1");
+
+    emit.mockImplementation((event, _payload, callback) => {
+      if (event === "RECONNECT_TEAM") {
+        callback?.({
+          success: true,
+          team: { id: "team-1", name: "Alpha", color: "#111111" },
+        });
+      }
+    });
+
+    const questionState: GameState = {
+      ...baseState,
+      phase: "QUESTION_ACTIVE",
+      currentQuestion: {
+        id: "question-crossword-empty",
+        roundId: "round-1",
+        questionText: "Fill the grid",
+        type: "CROSSWORD",
+        points: 10,
+        timeLimitSeconds: 30,
+        grading: "AUTO",
+        content: {
+          grid: [["A"]],
+          clues: {
+            across: [{ clue: "Letter", answer: "A", direction: "across", x: 0, y: 0, number: 1 }],
+            down: [],
+          },
+        },
+      },
+    };
+
+    const hook = renderHook(() => usePlayerSession(questionState));
+    await flushEffects();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(emit.mock.calls.filter(([event]) => event === "SUBMIT_ANSWER")).toHaveLength(0);
+    hook.unmount();
+  });
+
+  it("does not autosave untouched correct-the-error defaults", async () => {
+    window.localStorage.setItem("quizco_team_id", "team-1");
+    window.localStorage.setItem("quizco_selected_competition_id", "competition-1");
+
+    emit.mockImplementation((event, _payload, callback) => {
+      if (event === "RECONNECT_TEAM") {
+        callback?.({
+          success: true,
+          team: { id: "team-1", name: "Alpha", color: "#111111" },
+        });
+      }
+    });
+
+    const questionState: GameState = {
+      ...baseState,
+      phase: "QUESTION_ACTIVE",
+      currentQuestion: {
+        id: "question-correct-error-empty",
+        roundId: "round-1",
+        questionText: "Correct the sentence",
+        type: "CORRECT_THE_ERROR",
+        points: 10,
+        timeLimitSeconds: 30,
+        grading: "AUTO",
+        content: {
+          text: "The sky is green",
+          words: [
+            { wordIndex: 3, text: "green", alternatives: ["blue", "green"] },
+          ],
+          errorWordIndex: 3,
+          correctReplacement: "blue",
+        },
+      },
+    };
+
+    const hook = renderHook(() => usePlayerSession(questionState));
+    await flushEffects();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(emit.mock.calls.filter(([event]) => event === "SUBMIT_ANSWER")).toHaveLength(0);
+    hook.unmount();
+  });
+
+  it("deduplicates repeated chronology partial autosaves when the answer has not changed", async () => {
+    window.localStorage.setItem("quizco_team_id", "team-1");
+    window.localStorage.setItem("quizco_selected_competition_id", "competition-1");
+
+    emit.mockImplementation((event, _payload, callback) => {
+      if (event === "RECONNECT_TEAM") {
+        callback?.({
+          success: true,
+          team: { id: "team-1", name: "Alpha", color: "#111111" },
+        });
+      }
+    });
+
+    const questionState: GameState = {
+      ...baseState,
+      phase: "QUESTION_ACTIVE",
+      currentQuestion: {
+        id: "question-chronology-1",
+        roundId: "round-1",
+        questionText: "Put these in order",
+        type: "CHRONOLOGY",
+        points: 10,
+        timeLimitSeconds: 30,
+        grading: "AUTO",
+        content: {
+          items: [
+            { id: "c1", text: "First", order: 0 },
+            { id: "c2", text: "Second", order: 1 },
+          ],
+        },
+      },
+      teams: baseState.teams.map((team) =>
+        team.id === "team-1"
+          ? {
+            ...team,
+            lastAnswer: {
+              slotIds: ["c1", null],
+              poolIds: ["c2"],
+            },
+          }
+          : team,
+      ),
+    };
+
+    const hook = renderHook(() => usePlayerSession(questionState));
+    await flushEffects();
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    const submitCallsAfterFirstTick = emit.mock.calls.filter(
+      ([event]) => event === "SUBMIT_ANSWER",
+    );
+    expect(submitCallsAfterFirstTick).toHaveLength(1);
+    expect(submitCallsAfterFirstTick[0]?.[1]).toMatchObject({
+      competitionId: "competition-1",
+      teamId: "team-1",
+      questionId: "question-chronology-1",
+      answer: {
+        slotIds: ["c1", null],
+        poolIds: ["c2"],
+      },
+      isFinal: false,
+    });
+
+    hook.rerender();
+    await flushEffects();
+    await vi.advanceTimersByTimeAsync(500);
+
+    const submitCallsAfterSecondTick = emit.mock.calls.filter(
+      ([event]) => event === "SUBMIT_ANSWER",
+    );
+    expect(submitCallsAfterSecondTick).toHaveLength(1);
+
     hook.unmount();
   });
 });

--- a/apps/client/src/hooks/usePlayerSession.ts
+++ b/apps/client/src/hooks/usePlayerSession.ts
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AnswerContent,
+  ChronologyAnswer,
   Competition,
   CorrectTheErrorAnswer,
   CorrectTheErrorContent,
   GameState,
   MultipleChoiceContent,
+  Question,
   Team,
 } from "@quizco/shared";
 import type { TFunction } from "i18next";
@@ -13,11 +15,92 @@ import { socket, API_URL } from "../socket";
 import { getHydratedPlayerAnswerState } from "../components/player/utils/playerAnswerSync";
 import { useCorrectTheErrorPartialScore } from "../components/player/questions/correctTheError/useCorrectTheErrorPartialScore";
 import { getQuestionCorrectAnswer } from "../components/player/questionText";
+import {
+  isChronologyAnswer,
+  isCorrectTheErrorAnswer,
+  isNumberArray,
+  isRecordOfStringValues,
+  isStringArray,
+  isStringGrid,
+} from "../utils/answerGuards";
 
 const TEAM_ID_KEY = "quizco_team_id";
 const TEAM_NAME_KEY = "quizco_team_name";
 const TEAM_COLOR_KEY = "quizco_team_color";
 const SELECTED_COMP_ID_KEY = "quizco_selected_competition_id";
+
+export type PlayerDraftAnswer = AnswerContent | null;
+
+interface StoredPlayerSession {
+  competitionId: string | null;
+  teamId: string | null;
+  teamName: string;
+  teamColor: string;
+}
+
+function readStoredPlayerSession(): StoredPlayerSession {
+  return {
+    competitionId: localStorage.getItem(SELECTED_COMP_ID_KEY),
+    teamId: localStorage.getItem(TEAM_ID_KEY),
+    teamName: localStorage.getItem(TEAM_NAME_KEY) || "",
+    teamColor: localStorage.getItem(TEAM_COLOR_KEY) || "#3B82F6",
+  };
+}
+
+function isDefaultChronologyAnswer(
+  question: Extract<Question, { type: "CHRONOLOGY" }>,
+  answer: ChronologyAnswer,
+): boolean {
+  const initialPoolIds = question.content.items.map((item) => item.id);
+
+  return (
+    answer.slotIds.every((slotId) => slotId === null) &&
+    answer.poolIds.length === initialPoolIds.length &&
+    answer.poolIds.every((poolId, index) => poolId === initialPoolIds[index])
+  );
+}
+
+function shouldAutosaveDraftAnswer(
+  question: Question,
+  value: PlayerDraftAnswer,
+): value is AnswerContent {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  switch (question.type) {
+    case "MULTIPLE_CHOICE":
+      return isNumberArray(value) && value.length > 0;
+    case "CLOSED":
+    case "OPEN_WORD":
+      return typeof value === "string" && value.trim().length > 0;
+    case "CROSSWORD":
+      return (
+        isStringGrid(value) &&
+        value.some((row) => row.some((cell) => cell.trim().length > 0))
+      );
+    case "FILL_IN_THE_BLANKS":
+      return isStringArray(value) && value.some((entry) => entry.trim().length > 0);
+    case "MATCHING":
+      return (
+        isRecordOfStringValues(value) &&
+        Object.values(value).some((entry) => entry.trim().length > 0)
+      );
+    case "CHRONOLOGY":
+      return isChronologyAnswer(value) && !isDefaultChronologyAnswer(question, value);
+    case "TRUE_FALSE":
+      return typeof value === "boolean";
+    case "CORRECT_THE_ERROR":
+      return (
+        isCorrectTheErrorAnswer(value) &&
+        (value.selectedWordIndex >= 0 || value.correction.trim().length > 0)
+      );
+  }
+}
+
+function isSocketAnswer(value: PlayerDraftAnswer): value is AnswerContent {
+  return value !== null && value !== undefined;
+}
 
 export interface PlayerIdentity {
   teamId: string | null;
@@ -31,7 +114,7 @@ export interface PlayerSessionResult {
   joined: boolean;
   isReconnecting: boolean;
   identity: PlayerIdentity;
-  answer: AnswerContent;
+  answer: PlayerDraftAnswer;
   selectedIndices: number[];
   submissionStatus: "idle" | "success" | "error";
   currentTeam: Team | undefined;
@@ -41,13 +124,13 @@ export interface PlayerSessionResult {
   currentScore: number;
   setTeamName: (teamName: string) => void;
   setColor: (color: string) => void;
-  setAnswer: (value: AnswerContent) => void;
+  setAnswer: (value: PlayerDraftAnswer) => void;
   selectCompetition: (competitionId: string) => void;
   clearSelectedCompetition: () => void;
   joinTeam: () => void;
   leaveSession: () => void;
   toggleIndex: (index: number) => void;
-  submitAnswer: (value: AnswerContent, isFinal?: boolean) => void;
+  submitAnswer: (value: PlayerDraftAnswer, isFinal?: boolean) => void;
   getCorrectAnswer: (
     question: NonNullable<GameState["currentQuestion"]>,
     t: TFunction,
@@ -58,24 +141,21 @@ export interface PlayerSessionResult {
 
 interface DraftAnswerState {
   questionId: string | null;
-  answer: AnswerContent;
+  answer: PlayerDraftAnswer;
   selectedIndices: number[];
   submissionStatus: "idle" | "success" | "error";
 }
 
 export function usePlayerSession(state: GameState): PlayerSessionResult {
-  const savedCompetitionId = localStorage.getItem(SELECTED_COMP_ID_KEY);
-  const savedTeamId = localStorage.getItem(TEAM_ID_KEY);
-  const savedTeamName = localStorage.getItem(TEAM_NAME_KEY) || "";
-  const savedTeamColor = localStorage.getItem(TEAM_COLOR_KEY) || "#3B82F6";
+  const [initialSession] = useState(readStoredPlayerSession);
 
   const [competitions, setCompetitions] = useState<Competition[]>([]);
   const [selectedCompId, setSelectedCompId] = useState<string | null>(
-    savedCompetitionId,
+    initialSession.competitionId,
   );
-  const [teamId, setTeamId] = useState<string | null>(savedTeamId);
-  const [teamName, setTeamName] = useState(savedTeamName);
-  const [color, setColor] = useState(savedTeamColor);
+  const [teamId, setTeamId] = useState<string | null>(initialSession.teamId);
+  const [teamName, setTeamName] = useState(initialSession.teamName);
+  const [color, setColor] = useState(initialSession.teamColor);
   const [joined, setJoined] = useState(false);
   const [draftState, setDraftState] = useState<DraftAnswerState>({
     questionId: null,
@@ -84,7 +164,7 @@ export function usePlayerSession(state: GameState): PlayerSessionResult {
     submissionStatus: "idle",
   });
   const [isReconnecting, setIsReconnecting] = useState(
-    Boolean(savedTeamId && savedCompetitionId),
+    Boolean(initialSession.teamId && initialSession.competitionId),
   );
   const [loginError, setLoginError] = useState<string | null>(null);
 
@@ -123,7 +203,7 @@ export function usePlayerSession(state: GameState): PlayerSessionResult {
 
     return {
       questionId: state.currentQuestion.id,
-      answer: hydrated.answer as AnswerContent,
+      answer: hydrated.answer,
       selectedIndices: hydrated.selectedIndices,
       submissionStatus: "idle",
     };
@@ -146,16 +226,22 @@ export function usePlayerSession(state: GameState): PlayerSessionResult {
   }, [selectedCompId]);
 
   useEffect(() => {
-    if (!savedTeamId || !savedCompetitionId) {
+    const persistedTeamId = initialSession.teamId;
+    const persistedCompetitionId = initialSession.competitionId;
+
+    if (!persistedTeamId || !persistedCompetitionId) {
       return;
     }
 
     socket.emit(
       "RECONNECT_TEAM",
-      { competitionId: savedCompetitionId, teamId: savedTeamId },
+      {
+        competitionId: persistedCompetitionId,
+        teamId: persistedTeamId,
+      },
       (response: { success: boolean; team: { id?: string; name: string; color: string } }) => {
         if (response.success) {
-          const resolvedTeamId = response.team.id ?? savedTeamId;
+          const resolvedTeamId = response.team.id ?? persistedTeamId;
           setTeamId(resolvedTeamId);
           setTeamName(response.team.name);
           setColor(response.team.color);
@@ -169,7 +255,7 @@ export function usePlayerSession(state: GameState): PlayerSessionResult {
         setIsReconnecting(false);
       },
     );
-  }, [savedCompetitionId, savedTeamId]);
+  }, [initialSession.competitionId, initialSession.teamId]);
 
   useEffect(() => {
     lastPartialSubmissionKeyRef.current = null;
@@ -227,34 +313,6 @@ export function usePlayerSession(state: GameState): PlayerSessionResult {
     };
   }, [hydratedState.answer, hydratedState.selectedIndices, state.currentQuestion, teamId]);
 
-  useEffect(() => {
-    if (!joined || !teamId || state.phase !== "QUESTION_ACTIVE" || currentTeam?.isExplicitlySubmitted) {
-      return;
-    }
-
-    const timer = window.setTimeout(() => {
-      if (state.currentQuestion?.type !== "MULTIPLE_CHOICE" && answer !== "" && answer !== null && answer !== undefined) {
-        socket.emit("SUBMIT_ANSWER", {
-          competitionId: selectedCompId,
-          teamId,
-          questionId: state.currentQuestion?.id,
-          answer,
-          isFinal: false,
-        });
-      }
-    }, 500);
-
-    return () => window.clearTimeout(timer);
-  }, [
-    answer,
-    currentTeam?.isExplicitlySubmitted,
-    joined,
-    selectedCompId,
-    state.currentQuestion,
-    state.phase,
-    teamId,
-  ]);
-
   const selectCompetition = useCallback((competitionId: string) => {
     setSelectedCompId(competitionId);
     localStorage.setItem(SELECTED_COMP_ID_KEY, competitionId);
@@ -308,10 +366,22 @@ export function usePlayerSession(state: GameState): PlayerSessionResult {
   }, []);
 
   const submitAnswer = useCallback(
-    (value: AnswerContent, isFinal = false) => {
+    (value: PlayerDraftAnswer, isFinal = false) => {
       if (!state.currentQuestion || !selectedCompId || !teamId) {
         setLoginError("player.session_lost_rejoin");
         setJoined(false);
+        return;
+      }
+
+      if (!isSocketAnswer(value)) {
+        if (isFinal) {
+          setDraftState((previous) => ({
+            questionId: state.currentQuestion?.id ?? previous.questionId,
+            answer: value,
+            selectedIndices: previous.selectedIndices,
+            submissionStatus: "error",
+          }));
+        }
         return;
       }
 
@@ -350,6 +420,32 @@ export function usePlayerSession(state: GameState): PlayerSessionResult {
     [selectedCompId, state.currentQuestion, teamId],
   );
 
+  useEffect(() => {
+    if (!joined || !teamId || state.phase !== "QUESTION_ACTIVE" || currentTeam?.isExplicitlySubmitted) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      if (
+        state.currentQuestion &&
+        state.currentQuestion.type !== "MULTIPLE_CHOICE" &&
+        shouldAutosaveDraftAnswer(state.currentQuestion, answer)
+      ) {
+        submitAnswer(answer, false);
+      }
+    }, 500);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    answer,
+    currentTeam?.isExplicitlySubmitted,
+    joined,
+    state.currentQuestion,
+    state.phase,
+    submitAnswer,
+    teamId,
+  ]);
+
   const toggleIndex = useCallback(
     (index: number) => {
       if (currentTeam?.isExplicitlySubmitted) {
@@ -382,7 +478,7 @@ export function usePlayerSession(state: GameState): PlayerSessionResult {
   );
 
   const updateAnswer = useCallback(
-    (value: AnswerContent) => {
+    (value: PlayerDraftAnswer) => {
       setDraftState((previous) => ({
         questionId: currentQuestionId,
         answer: value,

--- a/apps/e2e/tests/question-types/chronology.spec.ts
+++ b/apps/e2e/tests/question-types/chronology.spec.ts
@@ -10,6 +10,10 @@ import {
 } from "../helpers/gameHarness";
 import { QUESTION_TYPE_SCENARIOS, runQuestionTypeScenario } from "../helpers/questionTypeScenarios";
 
+interface PendingAnswer {
+  team_name?: string;
+}
+
 test("Question type flow: CHRONOLOGY", async ({ browser }) => {
   await runQuestionTypeScenario(browser, QUESTION_TYPE_SCENARIOS.CHRONOLOGY);
 });
@@ -19,7 +23,7 @@ const dragByItem = async (
   itemTestId: string,
   targetTestId: string,
 ): Promise<void> => {
-  const item = page.getByTestId(itemTestId);
+  const item = page.getByTestId(itemTestId).first();
   const target = page.getByTestId(targetTestId).first();
 
   await expect(item).toBeVisible();
@@ -94,7 +98,8 @@ test("Chronology allows moving an item back to left pool after pool is empty", a
         .getByTestId(/chronology-item-/),
     ).toHaveCount(0);
 
-    await dragByItem(session.playerOnePage, "chronology-item-c1", "chronology-pool-dropzone");
+    await session.playerOnePage.getByTestId("chronology-item-c1").first().click();
+    await session.playerOnePage.getByTestId("chronology-pool-dropzone").click();
 
     await expect(
       session.playerOnePage
@@ -159,7 +164,7 @@ test("Chronology selector supports slot swap and pool item insertion targets", a
     await expect(session.playerOnePage.getByTestId("chronology-slot-0")).toContainText("One");
     await expect(session.playerOnePage.getByTestId("chronology-slot-1")).toContainText("Two");
 
-    await dragByItem(session.playerOnePage, "chronology-item-c1", "chronology-item-c2");
+    await dragByItem(session.playerOnePage, "chronology-item-c1", "chronology-slot-1");
     await expect(session.playerOnePage.getByTestId("chronology-slot-0")).toContainText("Two");
     await expect(session.playerOnePage.getByTestId("chronology-slot-1")).toContainText("One");
 
@@ -180,6 +185,73 @@ test("Chronology selector supports slot swap and pool item insertion targets", a
     await expect(session.hostPage.getByTestId("host-current-phase")).toHaveText("GRADING", {
       timeout: 20_000,
     });
+  } finally {
+    if (competitionId) {
+      await deleteCompetition(adminApi, competitionId);
+    }
+    if (session) {
+      await session.close();
+    }
+    await adminApi.dispose();
+  }
+});
+
+test("Chronology autosave ignores untouched default answers", async ({ browser }) => {
+  const adminApi = await createAdminApi();
+  let competitionId = "";
+  let session: Awaited<ReturnType<typeof createHostAndPlayers>> | null = null;
+
+  const getPendingAnswers = async (): Promise<PendingAnswer[]> => {
+    const pendingAnswersRes = await adminApi.get(
+      `/api/admin/pending-answers?competitionId=${competitionId}`,
+    );
+    expect(pendingAnswersRes.ok()).toBeTruthy();
+    return (await pendingAnswersRes.json()) as PendingAnswer[];
+  };
+
+  try {
+    const fixture = await createCompetitionWithQuestions(
+      adminApi,
+      "E2E Chronology Untouched Autosave",
+      [
+        {
+          questionText: "Chronology untouched autosave question",
+          type: "CHRONOLOGY",
+          timeLimitSeconds: 10,
+          content: {
+            items: [
+              { id: "c1", text: "First", order: 0 },
+              { id: "c2", text: "Second", order: 1 },
+            ],
+          },
+        },
+      ],
+    );
+    competitionId = fixture.competitionId;
+
+    session = await createHostAndPlayers(
+      browser,
+      competitionId,
+      "Chronology Autosave Team One",
+      "Chronology Autosave Team Two",
+    );
+
+    await moveToQuestionPreview(session.hostPage);
+    await movePreviewToActive(session.hostPage, "CHRONOLOGY");
+
+    await expect(session.playerOnePage.getByTestId("player-phase")).toHaveText("QUESTION_ACTIVE", {
+      timeout: 20_000,
+    });
+
+    await dragByItem(session.playerOnePage, "chronology-item-c1", "chronology-slot-0");
+
+    await expect.poll(
+      async () => (await getPendingAnswers()).length,
+      { timeout: 10_000 },
+    ).toBe(1);
+
+    const pendingAnswers = await getPendingAnswers();
+    expect(pendingAnswers[0]?.team_name).toBe("Chronology Autosave Team One");
   } finally {
     if (competitionId) {
       await deleteCompetition(adminApi, competitionId);


### PR DESCRIPTION
Persist the initial player session snapshot once, make draft answers explicitly nullable, and suppress autosave for untouched defaults so no-answer remains distinct from incorrect-answer. Add unit regressions for fresh joins, untouched true/false, chronology, crossword, and correct-the-error states, plus chronology e2e coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft answers are no longer automatically submitted when unchanged.
  * Repeated autosaves of the same answer content are now deduplicated.

* **Improvements**
  * Enhanced handling of empty draft answers across question types.
  * Improved answer validation logic for different question formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->